### PR TITLE
Backout D89330027 - filelock 3.20.1 doesn't exist on PyPI

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -104,9 +104,9 @@ execnet==2.1.1 \
     --hash=sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc \
     --hash=sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3
     # via pytest-xdist
-filelock==3.20.1 \
-    --hash=sha256:15d9e9a67306188a44baa72f569d2bfd803076269365fdea0934385da4dc361a \
-    --hash=sha256:b8360948b351b80f420878d8516519a2204b07aefcdcfd24912a5d33127f188c
+filelock==3.18.0 \
+    --hash=sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2 \
+    --hash=sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de
     # via virtualenv
 flake8==7.1.1 \
     --hash=sha256:049d058491e228e03e67b390f311bbf88fce2dbaa8fa673e7aea87b7198b8d38 \


### PR DESCRIPTION
Summary:
The codemod D89330027 bumped filelock from 3.18.0 to 3.20.1, but version
3.20.1 does not exist on PyPI. This was causing the GCM RPM build to fail
since mid December with ([conveyor](https://www.internalfb.com/conveyor/fair/gcm/releases)):

*ERROR: Could not find a version that satisfies the requirement filelock==3.20.1 ([logs](https://www.internalfb.com/sandcastle/workflow/4062246863900938728))*

This reverts filelock back to 3.18.0 which is a valid version.

Reviewed By: calebho, luccabb

Differential Revision: D92069472


