### PR TITLE
Add support for output from DCGM v4.x

### DIFF
--- a/gcm/tests/health_checks_tests/test_check_dcgmi.py
+++ b/gcm/tests/health_checks_tests/test_check_dcgmi.py
@@ -54,6 +54,17 @@ diag_pass_output = FakeShellCommandOut(
     0,
     '{"DCGM GPU Diagnostic": {"test_categories": [{"category": "Deployment", "tests": [{"name": "Blacklist", "results": [{"status": "Pass"}]}, {"name": "NVML Library", "results": [{"status": "Pass"}]}, {"name": "CUDA Main Library", "results": [{"status": "Pass"}]}, {"name": "Permissions and OS Blocks", "results": [{"status": "Pass"}]}, {"name": "Persistence Mode", "results": [{"status": "Pass"}]}, {"name": "Environment Variables", "results": [{"status": "Pass"}]}, {"name": "Page Retirement/Row Remap", "results": [{"status": "Pass"}]}, {"name": "Graphics Processes", "results": [{"status": "Pass"}]}, {"name": "Inforom", "results": [{"status": "Pass"}]}]}]}}',
 )
+# DCGM 4.x uses "DCGM Diagnostic" instead of "DCGM GPU Diagnostic" and has test_summary
+diag_pass_output_v4 = FakeShellCommandOut(
+    [],
+    0,
+    '{"DCGM Diagnostic": {"test_categories": [{"category": "Deployment", "tests": [{"name": "software", "results": [{"entity_group": "GPU", "entity_group_id": 1, "entity_id": 0, "status": "Pass"}], "test_summary": {"status": "Pass"}}]}]}}',
+)
+diag_fail_output_v4 = FakeShellCommandOut(
+    [],
+    0,
+    '{"DCGM Diagnostic": {"test_categories": [{"category": "Deployment", "tests": [{"name": "software", "results": [{"entity_group": "GPU", "entity_group_id": 1, "entity_id": 0, "status": "Fail"}], "test_summary": {"status": "Fail"}}]}]}}',
+)
 diag_fail_output = FakeShellCommandOut(
     [],
     0,
@@ -77,6 +88,7 @@ non_fatal_error_code_output = FakeShellCommandOut(
     "dcgmi_shell_command_tester, expected",
     [
         (diag_pass_output, (ExitCode.OK, "All checks passed")),
+        (diag_pass_output_v4, (ExitCode.OK, "All checks passed")),  # DCGM 4.x format
         (
             diag_fail_output,
             (
@@ -84,6 +96,10 @@ non_fatal_error_code_output = FakeShellCommandOut(
                 "Persistence Mode failed.\nEnvironment Variables warning",
             ),
         ),
+        (
+            diag_fail_output_v4,
+            (ExitCode.CRITICAL, "software failed"),
+        ),  # DCGM 4.x fail format
         (diag_warn_output, (ExitCode.WARN, "Persistence Mode warning")),
         (empty_output, (ExitCode.WARN, "dcgmi diag FAILED to execute")),
         (


### PR DESCRIPTION
Summary:
DCGM 4.x changed the JSON output format for the dcgmi diag command

3.x: "DCGM GPU Diagnostic"
4.x: "DCGM Diagnostic"

- Updated process_dcgmi_diag_output() to check for both "DCGM GPU Diagnostic" (3.x) and "DCGM Diagnostic" (4.x) keys
- Added diag_pass_output_v4 test case for DCGM 4.x format
- New _get_test_status() helper function - Handles different status locations:
    - DCGM 4.x: Uses test["test_summary"]["status"] (aggregated per-test summary)
    - DCGM 3.x: Uses test["results"][0]["status"] (backward compatible)

See the breaking changes in the release notes:
https://docs.nvidia.com/datacenter/dcgm/latest/release-notes/changelog.html#deprecations-and-breaking-changes

Reviewed By: levydori

Differential Revision: D92219750


