### PR TITLE
Add ci_skycastle RPM build CI signal for diff-time validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,6 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# Meta-internal CI
+skycastle/


### PR DESCRIPTION
Summary:
Add diff-time Skycastle CI signals that run the full GCM and healthchecks packman RPM builds with `--build-local` so build-breaking changes are caught before landing instead of only by contbuild post-land. This would have caught the recent isort==7.0.0 breakage where a Python 3.10+ dependency was pinned but the build container used Python 3.9.

Two `ci_skycastle` targets are added: one for `fb-gcm` and one for `fb-healthchecks`. Each runs `packman build` directly with `--build-local --only <pkg> --run-as-root` to execute the full RPM build pipeline (container setup via systemd-nspawn, pip install, pyoxidizer build) without publishing. Both are land-blocking, diff-only, with a 90-minute timeout on I3_SMALL|I4_SMALL instances. After a successful build, each workflow smoke-tests the resulting binary with `--help` and `--version`. The `ci_srcs` lists track all files that feed into the RPM builds: container and build shell scripts, Python sources, requirements files, pyoxidizer config, Makefile, and packman YAML.

Differential Revision: D93157502


