### PR TITLE
Add scrut smoke tests for GCM and healthchecks binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -281,3 +281,4 @@ go.work.sum
 
 # Meta-internal CI
 skycastle/
+scrut/


### PR DESCRIPTION
Summary: Add scrut-based CLI smoke tests for the `gcm` and `health_checks` Python binaries. Each test validates that the binary starts, prints help and version output, and handles subcommand help without errors. These complement the Skycastle RPM build CI (D93157502) by verifying the binaries actually run, not just that they build.

Differential Revision: D93161797


