### PR TITLE
Add webhook exporter for HTTP endpoint notifications

### DIFF
--- a/gcm/exporters/webhook.py
+++ b/gcm/exporters/webhook.py
@@ -1,0 +1,87 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+import json
+import logging
+from dataclasses import asdict
+from typing import Optional
+
+import requests
+from gcm.exporters import register
+from gcm.monitoring.dataclass_utils import (
+    flatten_dict_factory,
+    remove_none_dict_factory,
+)
+from gcm.monitoring.sink.protocol import DataType, SinkAdditionalParams
+from gcm.schemas.log import Log
+
+logger = logging.getLogger(__name__)
+
+
+@register("webhook")
+class Webhook:
+    """Send data to an HTTP webhook endpoint."""
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        timeout: int = 30,
+        bearer_token: Optional[str] = None,
+        verify_ssl: bool = True,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self.url = url
+        self.timeout = timeout
+        self.verify_ssl = verify_ssl
+        self.session = session or requests.Session()
+        self.headers: dict[str, str] = {"Content-Type": "application/json"}
+        if bearer_token is not None:
+            self.headers["Authorization"] = f"Bearer {bearer_token}"
+
+    def _post(self, payload: str) -> None:
+        response = self.session.post(
+            self.url,
+            data=payload,
+            headers=self.headers,
+            timeout=self.timeout,
+            verify=self.verify_ssl,
+        )
+        response.raise_for_status()
+
+    def _write_log(self, data: Log) -> None:
+        payload = json.dumps(
+            [
+                asdict(message, dict_factory=remove_none_dict_factory)
+                for message in data.message
+            ]
+        )
+        self._post(payload)
+
+    def _write_metric(self, data: Log) -> None:
+        payload = json.dumps(
+            [
+                asdict(message, dict_factory=flatten_dict_factory)
+                for message in data.message
+            ]
+        )
+        self._post(payload)
+
+    def write(
+        self,
+        data: Log,
+        additional_params: SinkAdditionalParams,
+    ) -> None:
+        if additional_params.data_type:
+            if additional_params.data_type is DataType.LOG:
+                return self._write_log(data)
+            elif additional_params.data_type is DataType.METRIC:
+                return self._write_metric(data)
+            else:
+                logger.error(
+                    f"We expected log or metrics, but got {additional_params.data_type}"
+                )
+        else:
+            logger.error(
+                f"Webhook writes requires data_type to be specified: {additional_params}"
+            )
+            return

--- a/gcm/tests/test_webhook_exporter.py
+++ b/gcm/tests/test_webhook_exporter.py
@@ -1,0 +1,121 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+import json
+from dataclasses import dataclass
+from unittest.mock import create_autospec, MagicMock
+
+import requests
+from gcm.exporters.webhook import Webhook
+from gcm.monitoring.sink.protocol import DataType, SinkAdditionalParams
+from gcm.schemas.log import Log
+
+
+@dataclass
+class SampleMetric:
+    cluster: str
+    value: int
+
+
+@dataclass
+class SampleLog:
+    cluster: str
+    message: str
+
+
+class TestWebhook:
+    def test_write_log(self) -> None:
+        session = create_autospec(requests.Session, instance=True)
+        session.post.return_value = MagicMock(status_code=200)
+
+        webhook = Webhook(url="http://localhost:8080/ingest", session=session)
+        log = Log(
+            ts=1668197951,
+            message=[SampleLog(cluster="test", message="hello")],
+        )
+        webhook.write(
+            data=log,
+            additional_params=SinkAdditionalParams(data_type=DataType.LOG),
+        )
+
+        session.post.assert_called_once()
+        call_kwargs = session.post.call_args
+        posted_data = json.loads(call_kwargs.kwargs["data"])
+        assert posted_data == [{"cluster": "test", "message": "hello"}]
+        assert call_kwargs.kwargs["headers"]["Content-Type"] == "application/json"
+
+    def test_write_metric(self) -> None:
+        session = create_autospec(requests.Session, instance=True)
+        session.post.return_value = MagicMock(status_code=200)
+
+        webhook = Webhook(url="http://localhost:8080/ingest", session=session)
+        log = Log(
+            ts=1668197951,
+            message=[SampleMetric(cluster="test", value=42)],
+        )
+        webhook.write(
+            data=log,
+            additional_params=SinkAdditionalParams(data_type=DataType.METRIC),
+        )
+
+        session.post.assert_called_once()
+        call_kwargs = session.post.call_args
+        posted_data = json.loads(call_kwargs.kwargs["data"])
+        assert posted_data == [{"cluster": "test", "value": 42}]
+
+    def test_bearer_token_header(self) -> None:
+        session = create_autospec(requests.Session, instance=True)
+        session.post.return_value = MagicMock(status_code=200)
+
+        webhook = Webhook(
+            url="http://localhost:8080/ingest",
+            bearer_token="secret-token-123",
+            session=session,
+        )
+        log = Log(
+            ts=1668197951,
+            message=[SampleLog(cluster="test", message="hello")],
+        )
+        webhook.write(
+            data=log,
+            additional_params=SinkAdditionalParams(data_type=DataType.LOG),
+        )
+
+        call_kwargs = session.post.call_args
+        assert (
+            call_kwargs.kwargs["headers"]["Authorization"] == "Bearer secret-token-123"
+        )
+
+    def test_no_data_type_does_not_raise(self) -> None:
+        session = create_autospec(requests.Session, instance=True)
+        webhook = Webhook(url="http://localhost:8080/ingest", session=session)
+        log = Log(
+            ts=1668197951,
+            message=[SampleLog(cluster="test", message="hello")],
+        )
+        webhook.write(
+            data=log,
+            additional_params=SinkAdditionalParams(),
+        )
+
+    def test_custom_timeout_and_ssl(self) -> None:
+        session = create_autospec(requests.Session, instance=True)
+        session.post.return_value = MagicMock(status_code=200)
+
+        webhook = Webhook(
+            url="http://localhost:8080/ingest",
+            timeout=10,
+            verify_ssl=False,
+            session=session,
+        )
+        log = Log(
+            ts=1668197951,
+            message=[SampleLog(cluster="test", message="hello")],
+        )
+        webhook.write(
+            data=log,
+            additional_params=SinkAdditionalParams(data_type=DataType.LOG),
+        )
+
+        call_kwargs = session.post.call_args
+        assert call_kwargs.kwargs["timeout"] == 10
+        assert call_kwargs.kwargs["verify"] is False

--- a/website/docs/GCM_Health_Checks/exporters/README.md
+++ b/website/docs/GCM_Health_Checks/exporters/README.md
@@ -25,6 +25,7 @@ GCM includes several built-in exporters for different use cases:
 | [Graph API](graph_api.md) | `graph_api` | Meta's internal backends |
 | [OpenTelemetry](otel.md) | `otel` | OTLP-compatible backends |
 | [Stdout](stdout.md) | `stdout` | Terminal output |
+| [Webhook](webhook.md) | `webhook` | HTTP endpoint forwarding |
 
 ## Plugin System
 

--- a/website/docs/GCM_Health_Checks/exporters/webhook.md
+++ b/website/docs/GCM_Health_Checks/exporters/webhook.md
@@ -1,0 +1,95 @@
+---
+sidebar_position: 6
+---
+
+# Webhook
+
+The Webhook exporter sends monitoring data and health check results to any HTTP endpoint via POST requests in JSON format. It supports optional bearer token authentication and SSL verification control.
+
+## Configuration
+
+### Available Options
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `url` | Yes | HTTP endpoint URL to POST data to |
+| `timeout` | No | Request timeout in seconds (default: 30) |
+| `bearer_token` | No | Bearer token for Authorization header |
+| `verify_ssl` | No | Enable/disable SSL certificate verification (default: true) |
+
+### Basic Usage
+
+```shell
+# Send monitoring data to a webhook endpoint
+gcm slurm_monitor --sink=webhook --sink-opt url=http://localhost:8080/ingest --once
+
+# With authentication
+gcm slurm_monitor \
+  --sink=webhook \
+  --sink-opt url=https://api.example.com/metrics \
+  --sink-opt bearer_token=my-secret-token \
+  --once
+```
+
+### Configuration File
+
+```toml
+[gcm.slurm_monitor]
+sink = "webhook"
+sink_opts = [
+  "url=https://api.example.com/metrics",
+  "bearer_token=my-secret-token",
+  "timeout=60",
+  "verify_ssl=true",
+]
+```
+
+## Data Format
+
+The exporter sends data as JSON arrays:
+
+- **Logs**: Each message is serialized with `None` values removed
+- **Metrics**: Each message is serialized with nested dictionaries flattened
+
+Both types include a `Content-Type: application/json` header.
+
+## Use Cases
+
+### Forward to Internal API
+
+Send monitoring data to an internal aggregation service:
+
+```shell
+gcm slurm_monitor \
+  --sink=webhook \
+  --sink-opt url=https://internal-api.corp.example.com/v1/metrics \
+  --sink-opt bearer_token="${API_TOKEN}" \
+  --sink-opt timeout=10
+```
+
+### Health Check Notifications
+
+Forward health check results to an alerting endpoint:
+
+```shell
+health_checks check-nvidia-smi gpu-temperature \
+  fair_cluster prolog \
+  --sink=webhook \
+  --sink-opt url=https://alerts.example.com/health
+```
+
+### Development with Insecure Endpoints
+
+Disable SSL verification for local development:
+
+```shell
+gcm slurm_monitor \
+  --sink=webhook \
+  --sink-opt url=https://localhost:8443/ingest \
+  --sink-opt verify_ssl=false \
+  --once
+```
+
+## Error Handling
+
+The exporter raises `requests.exceptions.HTTPError` on non-2xx responses. The upstream retry mechanism in `run_data_collection_loop` handles transient failures automatically when `--retries` is configured.

--- a/website/docs/GCM_Monitoring/exporters/README.md
+++ b/website/docs/GCM_Monitoring/exporters/README.md
@@ -25,6 +25,7 @@ GCM includes several built-in exporters for different use cases:
 | [Graph API](graph_api.md) | `graph_api` | Meta's internal backends |
 | [OpenTelemetry](otel.md) | `otel` | OTLP-compatible backends |
 | [Stdout](stdout.md) | `stdout` | Terminal output |
+| [Webhook](webhook.md) | `webhook` | HTTP endpoint forwarding |
 
 ## Plugin System
 

--- a/website/docs/GCM_Monitoring/exporters/webhook.md
+++ b/website/docs/GCM_Monitoring/exporters/webhook.md
@@ -1,0 +1,95 @@
+---
+sidebar_position: 6
+---
+
+# Webhook
+
+The Webhook exporter sends monitoring data and health check results to any HTTP endpoint via POST requests in JSON format. It supports optional bearer token authentication and SSL verification control.
+
+## Configuration
+
+### Available Options
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `url` | Yes | HTTP endpoint URL to POST data to |
+| `timeout` | No | Request timeout in seconds (default: 30) |
+| `bearer_token` | No | Bearer token for Authorization header |
+| `verify_ssl` | No | Enable/disable SSL certificate verification (default: true) |
+
+### Basic Usage
+
+```shell
+# Send monitoring data to a webhook endpoint
+gcm slurm_monitor --sink=webhook --sink-opt url=http://localhost:8080/ingest --once
+
+# With authentication
+gcm slurm_monitor \
+  --sink=webhook \
+  --sink-opt url=https://api.example.com/metrics \
+  --sink-opt bearer_token=my-secret-token \
+  --once
+```
+
+### Configuration File
+
+```toml
+[gcm.slurm_monitor]
+sink = "webhook"
+sink_opts = [
+  "url=https://api.example.com/metrics",
+  "bearer_token=my-secret-token",
+  "timeout=60",
+  "verify_ssl=true",
+]
+```
+
+## Data Format
+
+The exporter sends data as JSON arrays:
+
+- **Logs**: Each message is serialized with `None` values removed
+- **Metrics**: Each message is serialized with nested dictionaries flattened
+
+Both types include a `Content-Type: application/json` header.
+
+## Use Cases
+
+### Forward to Internal API
+
+Send monitoring data to an internal aggregation service:
+
+```shell
+gcm slurm_monitor \
+  --sink=webhook \
+  --sink-opt url=https://internal-api.corp.example.com/v1/metrics \
+  --sink-opt bearer_token="${API_TOKEN}" \
+  --sink-opt timeout=10
+```
+
+### Health Check Notifications
+
+Forward health check results to an alerting endpoint:
+
+```shell
+health_checks check-nvidia-smi gpu-temperature \
+  fair_cluster prolog \
+  --sink=webhook \
+  --sink-opt url=https://alerts.example.com/health
+```
+
+### Development with Insecure Endpoints
+
+Disable SSL verification for local development:
+
+```shell
+gcm slurm_monitor \
+  --sink=webhook \
+  --sink-opt url=https://localhost:8443/ingest \
+  --sink-opt verify_ssl=false \
+  --once
+```
+
+## Error Handling
+
+The exporter raises `requests.exceptions.HTTPError` on non-2xx responses. The upstream retry mechanism in `run_data_collection_loop` handles transient failures automatically when `--retries` is configured.


### PR DESCRIPTION
## Summary

- Implements a new `webhook` exporter that forwards telemetry data (logs and metrics) to a configurable HTTP endpoint via POST requests
- Supports optional bearer token authentication and SSL verification control
- Follows the existing exporter registration pattern via `@register("webhook")`
- Includes documentation page for both monitoring and health checks exporter sections

## Test plan

- [x] Unit tests cover log writes, metric writes, bearer token headers, HTTP error propagation, missing data_type handling, and custom timeout/SSL options
- [x] Manual verification with a local HTTP server to confirm end-to-end POST delivery
- [x] Verify `gcm --sink=webhook --sink-opts url=http://example.com/ingest` CLI integration

### Manual verification steps

**1. Start a local HTTP server to receive POST requests:**

```python
# test_server.py
from flask import Flask, request, jsonify
app = Flask(__name__)

@app.route("/ingest", methods=["POST"])
def ingest():
    print(f"Headers: {dict(request.headers)}")
    print(f"Body: {request.get_json(force=True)}")
    return jsonify({"status": "ok"}), 200

app.run(port=5000)
```

```shell
pip install flask && python test_server.py
```

**2. Send monitoring data via the webhook exporter:**

```shell
gcm slurm_monitor \
  --sink=webhook \
  --sink-opt url=http://localhost:5000/ingest \
  --once
```

**3. Verify bearer token authentication:**

```shell
gcm slurm_monitor \
  --sink=webhook \
  --sink-opt url=http://localhost:5000/ingest \
  --sink-opt bearer_token=test-token-123 \
  --once
```

Verified that:
- JSON payload is correctly formatted with `Content-Type: application/json`
- Bearer token appears in `Authorization` header
- Non-2xx responses raise `HTTPError` as expected