### PR TITLE
Add Discord link to website and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ GCM is a monorepo with the following components:
 - [Health Checks](gcm/health_checks/): Verifies the proper functioning of hardware, software, network, storage, and services throughout the job lifecycle.
 - [Telemetry Processor / GPU Metrics](slurmprocessor/): Enhances OpenTelemetry data by correlating telemetry with Slurm metadata, enabling attribution of metrics (e.g., GPU utilization) to specific jobs and users.
 
-For more information, check our [documentation](https://facebookresearch.github.io/gcm/).
+For more information, check our [documentation](https://facebookresearch.github.io/gcm/). Join our [Discord](https://discord.gg/PwUaeyxw) community!
 
 ## Contributing
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -135,6 +135,11 @@ const config = {
             label: 'Discussions',
             position: 'right',
           },
+          {
+            href: 'https://discord.gg/PwUaeyxw',
+            label: 'Discord',
+            position: 'right',
+          },
         ],
       },
       footer: {
@@ -167,6 +172,10 @@ const config = {
               {
                 label: 'Discussions',
                 href: 'https://github.com/facebookresearch/gcm/discussions',
+              },
+              {
+                label: 'Discord',
+                href: 'https://discord.gg/PwUaeyxw',
               },
             ],
           },


### PR DESCRIPTION
## Summary
- Adds Discord invite link to the website navbar and footer: https://discord.gg/PwUaeyxw
- Adds Discord invite link to the main README

## Test plan
- [ ] Verify the Discord link renders correctly on the website navbar and footer
- [ ] Verify the Discord link renders correctly in the README on GitHub