### PR TITLE
Add OSS CI checks (flake8, ufmt, mypy) to internal CI

### DIFF
--- a/gcm/exporters/graph_api.py
+++ b/gcm/exporters/graph_api.py
@@ -18,7 +18,6 @@ from requests.exceptions import RequestException
 
 from typing_extensions import Never
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/gcm/monitoring/cli/sacct_backfill.py
+++ b/gcm/monitoring/cli/sacct_backfill.py
@@ -10,6 +10,7 @@ if invoked twice on the same underlying `sacct` data, this script will write the
 twice. Downstream data processing should account for this
 fact and decide what to do with duplicate data.
 """
+
 import csv
 import logging
 import os

--- a/gcm/monitoring/cli/sacct_backfill_server.py
+++ b/gcm/monitoring/cli/sacct_backfill_server.py
@@ -10,6 +10,7 @@ data is different across clusters; in general, H1 is much smaller than H2 so it 
 fewer jobs. In order to prevent H1 from getting ahead of H2, we need to synchronize
 the progress using a barrier.
 """
+
 import logging
 from functools import lru_cache
 from multiprocessing import Barrier

--- a/gcm/monitoring/cli/sacct_publish.py
+++ b/gcm/monitoring/cli/sacct_publish.py
@@ -52,7 +52,6 @@ from gcm.schemas.slurm.sacct import SacctPayload
 from typeguard import typechecked
 from typing_extensions import Literal
 
-
 LOGGER_NAME = "sacct_publish"
 
 logger: logging.Logger = logging.getLogger(

--- a/gcm/monitoring/cli/slurm_job_monitor.py
+++ b/gcm/monitoring/cli/slurm_job_monitor.py
@@ -2,6 +2,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 """Read SLURM node information and publish the data to a sink"""
+
 from __future__ import annotations
 
 import logging

--- a/gcm/monitoring/meta_utils/ods.py
+++ b/gcm/monitoring/meta_utils/ods.py
@@ -2,6 +2,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 """Write datapoints to ODS via GraphQL."""
+
 from __future__ import annotations
 
 import json

--- a/gcm/monitoring/sink/protocol.py
+++ b/gcm/monitoring/sink/protocol.py
@@ -6,7 +6,6 @@ from typing import Optional, Protocol, runtime_checkable, TypeVar
 
 from gcm.schemas.log import Log
 
-
 TIn_contra = TypeVar("TIn_contra", contravariant=True)
 
 

--- a/gcm/monitoring/slurm/sinfo.py
+++ b/gcm/monitoring/slurm/sinfo.py
@@ -28,7 +28,6 @@ from gcm.schemas.slurm.sinfo_cpus_gpus import SinfoCpusGpus
 from gcm.schemas.slurm.sinfo_node_states import SinfoNodeStates
 from gcm.schemas.slurm.slurm_log import SLURMLogAccountMetrics
 
-
 LOGGER_NAME = "slurm.sinfo"
 log_error = error.log_error(logger_name=LOGGER_NAME)
 

--- a/gcm/monitoring/utils/monitor.py
+++ b/gcm/monitoring/utils/monitor.py
@@ -2,6 +2,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 """Utility functions for the various monitors."""
+
 from __future__ import annotations
 
 import inspect

--- a/gcm/schemas/dataclass.py
+++ b/gcm/schemas/dataclass.py
@@ -3,7 +3,6 @@
 from dataclasses import field
 from typing import Callable, cast, Optional, TypeVar
 
-
 T = TypeVar("T")
 
 

--- a/gcm/schemas/log.py
+++ b/gcm/schemas/log.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable, TYPE_CHECKING
 
-
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance
 

--- a/gcm/tests/test_sacctmgr_qos.py
+++ b/gcm/tests/test_sacctmgr_qos.py
@@ -16,7 +16,6 @@ from gcm.tests import data
 from gcm.tests.fakes import FakeClock
 from typeguard import typechecked
 
-
 TEST_CLUSTER = "test_cluster"
 TEST_DS = "test_ds"
 

--- a/gcm/tests/test_sacctmgr_user.py
+++ b/gcm/tests/test_sacctmgr_user.py
@@ -16,7 +16,6 @@ from gcm.tests import data
 from gcm.tests.fakes import FakeClock
 from typeguard import typechecked
 
-
 TEST_CLUSTER = "test_cluster"
 TEST_DS = "test_ds"
 


### PR DESCRIPTION
Summary:
D94605913 (and others) pass Facebook internal CI but fail on GitHub CI
because the OSS repo runs additional checks that internal CI does not:
- `nox -s lint` (flake8)
- `nox -s format` (ufmt = usort + black)
- `nox -s typecheck` (mypy)

This diff adds a `buck_sh_test` target (`oss-checks`) that runs all three
checks using the same pinned dev-requirements.txt as GitHub CI. A `ci_hint`
ensures the test is triggered whenever GCM source or config files change.

Differential Revision: D94770953


