### PR TITLE
Fixed stdout/do_nothing sinks by having explicit inits

### DIFF
--- a/gcm/exporters/do_nothing.py
+++ b/gcm/exporters/do_nothing.py
@@ -9,6 +9,19 @@ from gcm.schemas.log import Log
 class DoNothing:
     """Placeholder Sink"""
 
+    def __init__(self, **kwargs: object) -> None:
+        """Initialize DoNothing sink.
+
+        Explicit __init__ is required for compatibility with certain versions
+        of typeguard's typechecked() decorator used in monitor.py line 110.
+
+        Args:
+            **kwargs: Accepts any keyword arguments to be compatible with
+                      sink_kwargs passed from monitor.py line 117. Currently
+                      ignores all parameters as DoNothing doesn't need configuration.
+        """
+        pass
+
     def write(
         self,
         data: Log,

--- a/gcm/exporters/stdout.py
+++ b/gcm/exporters/stdout.py
@@ -20,6 +20,19 @@ logger = logging.getLogger(__name__)
 class Stdout:
     """Write data to stdout."""
 
+    def __init__(self, **kwargs: object) -> None:
+        """Initialize Stdout sink.
+
+        Explicit __init__ is required for compatibility with certain versions
+        of typeguard's typechecked() decorator used in monitor.py line 110.
+
+        Args:
+            **kwargs: Accepts any keyword arguments to be compatible with
+                      sink_kwargs passed from monitor.py line 117. Currently
+                      ignores all parameters as Stdout doesn't need configuration.
+        """
+        pass
+
     def _write_log(self, data: Log) -> None:
         print(
             json.dumps(


### PR DESCRIPTION
Summary:
For reasons I don't fully understand, `gcm sacctmgr_qos --sink=stdout --stdout --once` fails with `TypeError: Stdout() takes no arguments` on `avaadmin4045`.

Even more confusingly, it works on `rscadmin4000` (SBX admin node), using a manually-copied one.

Regardless, it seems that by adding `__init__()` methods to these sinks makes them work on all machines including `avaadmin4045`.

Differential Revision: D88093589


