### PR TITLE
Add HealthCheckRuntime context manager for shared boilerplate [1/2]

### DIFF
--- a/gcm/health_checks/check_utils/runtime.py
+++ b/gcm/health_checks/check_utils/runtime.py
@@ -8,7 +8,7 @@ from collections.abc import Collection
 from contextlib import ExitStack
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, ContextManager, Literal, NoReturn, Optional, Type
+from typing import Callable, ContextManager, Literal, NoReturn, Optional, Tuple, Type
 
 import gni_lib
 from gcm.health_checks.check_utils.output_context_manager import OutputContext
@@ -19,10 +19,46 @@ from gcm.monitoring.utils.monitor import init_logger
 from gcm.schemas.health_check.health_check_name import HealthCheckName
 
 
+def _default_get_hostname() -> str:
+    return socket.gethostname()
+
+
+def _default_get_gpu_node_id() -> Optional[str]:
+    return gni_lib.get_gpu_node_id()
+
+
+def _default_init_logger(
+    logger_name: str, log_dir: str, log_name: str, log_level: int
+) -> Tuple[logging.Logger, logging.Handler]:
+    return init_logger(
+        logger_name=logger_name,
+        log_dir=log_dir,
+        log_name=log_name,
+        log_level=log_level,
+    )
+
+
+def _default_get_derived_cluster(
+    cluster: str, heterogeneous_cluster_v1: bool, data: dict
+) -> str:
+    return get_derived_cluster(
+        cluster=cluster,
+        heterogeneous_cluster_v1=heterogeneous_cluster_v1,
+        data=data,
+    )
+
+
 @dataclass
 class HealthCheckRuntime(ContextManager["HealthCheckRuntime"]):
+    """Context manager encapsulating shared health check setup and teardown.
+
+    Handles logger initialization, GPU node ID detection, derived cluster
+    resolution, TelemetryContext/OutputContext lifecycle, and killswitch
+    checking. Use ``finish()`` to set the final exit code and terminate.
+    """
+
     cluster: str
-    type: CHECK_TYPE
+    check_type: CHECK_TYPE
     log_level: LOG_LEVEL
     log_folder: str
     sink: str
@@ -31,6 +67,16 @@ class HealthCheckRuntime(ContextManager["HealthCheckRuntime"]):
     heterogeneous_cluster_v1: bool
     health_check_name: HealthCheckName
     killswitch_getter: Callable[[], bool]
+
+    # Injectable dependencies for testing.
+    get_hostname: Callable[[], str] = _default_get_hostname
+    get_gpu_node_id: Callable[[], Optional[str]] = _default_get_gpu_node_id
+    init_logger: Callable[
+        [str, str, str, int], Tuple[logging.Logger, logging.Handler]
+    ] = _default_init_logger
+    get_derived_cluster: Callable[[str, bool, dict], str] = _default_get_derived_cluster
+    telemetry_context_factory: Callable[..., ContextManager] = TelemetryContext
+    output_context_factory: Callable[..., ContextManager] = OutputContext
 
     logger: logging.Logger = field(init=False)
     node: str = field(init=False)
@@ -41,44 +87,45 @@ class HealthCheckRuntime(ContextManager["HealthCheckRuntime"]):
     _stack: ExitStack = field(init=False)
 
     def __enter__(self) -> "HealthCheckRuntime":
-        self.node = socket.gethostname()
-        self.logger, _ = init_logger(
-            logger_name=self.type,
-            log_dir=str(Path(self.log_folder) / self.type / "_logs"),
-            log_name=self.node + ".log",
-            log_level=getattr(logging, self.log_level),
+        self.node = self.get_hostname()
+        self.logger, _ = self.init_logger(
+            self.check_type,
+            str(Path(self.log_folder) / (self.check_type + "_logs")),
+            self.node + ".log",
+            getattr(logging, self.log_level),
         )
         self.logger.info(
             "%s: cluster: %s, node: %s, type: %s",
             self.health_check_name.value,
             self.cluster,
             self.node,
-            self.type,
+            self.check_type,
         )
         try:
-            self.gpu_node_id = gni_lib.get_gpu_node_id()
+            self.gpu_node_id = self.get_gpu_node_id()
         except Exception as e:
             self.gpu_node_id = None
             self.logger.warning(
-                f"Could not get gpu_node_id, likely not a GPU host: {e}"
+                "Could not get gpu_node_id, likely not a GPU host: %s", e
             )
 
-        self.derived_cluster = get_derived_cluster(
-            cluster=self.cluster,
-            heterogeneous_cluster_v1=self.heterogeneous_cluster_v1,
-            data={"Node": self.node},
+        self.derived_cluster = self.get_derived_cluster(
+            self.cluster,
+            self.heterogeneous_cluster_v1,
+            {"Node": self.node},
         )
 
+        # Manage ExitStack manually so it spans both __enter__ and __exit__.
         self._stack = ExitStack()
         self._stack.__enter__()
         self._stack.enter_context(
-            TelemetryContext(
+            self.telemetry_context_factory(
                 sink=self.sink,
                 sink_opts=self.sink_opts,
                 logger=self.logger,
                 cluster=self.cluster,
                 derived_cluster=self.derived_cluster,
-                type=self.type,
+                type=self.check_type,
                 name=self.health_check_name.value,
                 node=self.node,
                 get_exit_code_msg=lambda: (self.exit_code, self.msg),
@@ -86,8 +133,8 @@ class HealthCheckRuntime(ContextManager["HealthCheckRuntime"]):
             )
         )
         self._stack.enter_context(
-            OutputContext(
-                self.type,
+            self.output_context_factory(
+                self.check_type,
                 self.health_check_name,
                 lambda: (self.exit_code, self.msg),
                 self.verbose_out,
@@ -96,11 +143,12 @@ class HealthCheckRuntime(ContextManager["HealthCheckRuntime"]):
 
         if self.killswitch_getter():
             self.exit_code = ExitCode.OK
-            self.logger.info(
-                "%s is disabled by killswitch",
-                self.health_check_name.value,
-            )
-            sys.exit(0)
+            self.msg = f"{self.health_check_name.value} is disabled by killswitch."
+            self.logger.info(self.msg)
+            # Properly clean contexts before exit since __exit__ is not
+            # called when SystemExit is raised inside __enter__.
+            self._stack.__exit__(None, None, None)
+            sys.exit(self.exit_code.value)
 
         return self
 
@@ -114,6 +162,7 @@ class HealthCheckRuntime(ContextManager["HealthCheckRuntime"]):
         return False
 
     def finish(self, exit_code: ExitCode, msg: str) -> NoReturn:
+        """Set the final exit code and message, then terminate via ``sys.exit``."""
         self.exit_code = exit_code
         self.msg = msg
         sys.exit(exit_code.value)

--- a/gcm/tests/health_checks_tests/test_runtime.py
+++ b/gcm/tests/health_checks_tests/test_runtime.py
@@ -3,8 +3,8 @@
 """Tests for the HealthCheckRuntime context manager."""
 
 import logging
-from typing import Callable
-from unittest.mock import MagicMock, patch
+from typing import Callable, Optional
+from unittest.mock import MagicMock
 
 import pytest
 from gcm.health_checks.check_utils.runtime import HealthCheckRuntime
@@ -12,12 +12,30 @@ from gcm.health_checks.types import ExitCode
 from gcm.schemas.health_check.health_check_name import HealthCheckName
 
 
+def _fake_init_logger(
+    logger_name: str, log_dir: str, log_name: str, log_level: int
+) -> tuple:
+    return (logging.getLogger("test"), MagicMock())
+
+
+def _fake_get_derived_cluster(
+    cluster: str, heterogeneous_cluster_v1: bool, data: dict
+) -> str:
+    return "derived_test"
+
+
 def _make_runtime(
     killswitch_getter: Callable[[], bool] = lambda: False,
+    get_hostname: Callable[[], str] = lambda: "testnode01",
+    get_gpu_node_id: Callable[[], Optional[str]] = lambda: "gpu-0",
+    init_logger: Callable = _fake_init_logger,
+    get_derived_cluster: Callable = _fake_get_derived_cluster,
+    telemetry_context_factory: Optional[Callable] = None,
+    output_context_factory: Optional[Callable] = None,
 ) -> HealthCheckRuntime:
-    return HealthCheckRuntime(
+    rt = HealthCheckRuntime(
         cluster="test_cluster",
-        type="prolog",
+        check_type="prolog",
         log_level="INFO",
         log_folder="/tmp",
         sink="do_nothing",
@@ -26,54 +44,29 @@ def _make_runtime(
         heterogeneous_cluster_v1=False,
         health_check_name=HealthCheckName.CHECK_SENSORS,
         killswitch_getter=killswitch_getter,
+        get_hostname=get_hostname,
+        get_gpu_node_id=get_gpu_node_id,
+        init_logger=init_logger,
+        get_derived_cluster=get_derived_cluster,
     )
+    if telemetry_context_factory is not None:
+        rt.telemetry_context_factory = telemetry_context_factory
+    if output_context_factory is not None:
+        rt.output_context_factory = output_context_factory
+    return rt
 
 
-@patch(
-    "gcm.health_checks.check_utils.runtime.get_derived_cluster",
-    return_value="derived_test",
-)
-@patch("gcm.health_checks.check_utils.runtime.gni_lib")
-@patch("gcm.health_checks.check_utils.runtime.init_logger")
-@patch("gcm.health_checks.check_utils.runtime.socket")
-def test_enter_initializes_fields(
-    mock_socket: MagicMock,
-    mock_init_logger: MagicMock,
-    mock_gni: MagicMock,
-    mock_derived: MagicMock,
-) -> None:
+def test_enter_initializes_fields() -> None:
     """Verify __enter__ populates logger, node, gpu_node_id, and derived_cluster."""
-    mock_socket.gethostname.return_value = "testnode01"
-    test_logger = logging.getLogger("test")
-    mock_init_logger.return_value = (test_logger, MagicMock())
-    mock_gni.get_gpu_node_id.return_value = "gpu-0"
-
-    rt = _make_runtime()
-    with rt as runtime:
-        assert runtime.node == "testnode01"
-        assert runtime.logger is test_logger
-        assert runtime.gpu_node_id == "gpu-0"
-        assert runtime.derived_cluster == "derived_test"
+    with _make_runtime() as rt:
+        assert rt.node == "testnode01"
+        assert rt.logger is not None
+        assert rt.gpu_node_id == "gpu-0"
+        assert rt.derived_cluster == "derived_test"
 
 
-@patch(
-    "gcm.health_checks.check_utils.runtime.get_derived_cluster",
-    return_value="test_cluster",
-)
-@patch("gcm.health_checks.check_utils.runtime.gni_lib")
-@patch("gcm.health_checks.check_utils.runtime.init_logger")
-@patch("gcm.health_checks.check_utils.runtime.socket")
-def test_killswitch_enabled_exits_ok(
-    mock_socket: MagicMock,
-    mock_init_logger: MagicMock,
-    mock_gni: MagicMock,
-    mock_derived: MagicMock,
-) -> None:
-    """When killswitch_getter returns True, sys.exit should be called with 0."""
-    mock_socket.gethostname.return_value = "testnode01"
-    mock_init_logger.return_value = (logging.getLogger("test"), MagicMock())
-    mock_gni.get_gpu_node_id.return_value = "gpu-0"
-
+def test_killswitch_enabled_exits_ok() -> None:
+    """When killswitch_getter returns True, sys.exit(0) is raised and msg is set."""
     with pytest.raises(SystemExit) as exc_info:
         with _make_runtime(killswitch_getter=lambda: True):
             pytest.fail(
@@ -83,24 +76,42 @@ def test_killswitch_enabled_exits_ok(
     assert exc_info.value.code == ExitCode.OK.value
 
 
-@patch(
-    "gcm.health_checks.check_utils.runtime.get_derived_cluster",
-    return_value="test_cluster",
-)
-@patch("gcm.health_checks.check_utils.runtime.gni_lib")
-@patch("gcm.health_checks.check_utils.runtime.init_logger")
-@patch("gcm.health_checks.check_utils.runtime.socket")
-def test_killswitch_disabled_continues(
-    mock_socket: MagicMock,
-    mock_init_logger: MagicMock,
-    mock_gni: MagicMock,
-    mock_derived: MagicMock,
-) -> None:
-    """When killswitch_getter returns False, the with block body should execute normally."""
-    mock_socket.gethostname.return_value = "testnode01"
-    mock_init_logger.return_value = (logging.getLogger("test"), MagicMock())
-    mock_gni.get_gpu_node_id.return_value = "gpu-0"
+def test_killswitch_cleans_up_contexts() -> None:
+    """When killswitch fires, both contexts must be entered and exited."""
+    mock_telem_cls = MagicMock()
+    mock_telem_instance = MagicMock()
+    mock_telem_cls.return_value = mock_telem_instance
 
+    mock_output_cls = MagicMock()
+    mock_output_instance = MagicMock()
+    mock_output_cls.return_value = mock_output_instance
+
+    with pytest.raises(SystemExit):
+        with _make_runtime(
+            killswitch_getter=lambda: True,
+            telemetry_context_factory=mock_telem_cls,
+            output_context_factory=mock_output_cls,
+        ):
+            pass
+
+    mock_telem_instance.__enter__.assert_called_once()
+    mock_telem_instance.__exit__.assert_called_once()
+    mock_output_instance.__enter__.assert_called_once()
+    mock_output_instance.__exit__.assert_called_once()
+
+
+def test_killswitch_sets_msg() -> None:
+    """When killswitch fires, msg should be set for TelemetryContext/OutputContext."""
+    rt = _make_runtime(killswitch_getter=lambda: True)
+    with pytest.raises(SystemExit):
+        rt.__enter__()
+
+    assert rt.exit_code == ExitCode.OK
+    assert rt.msg == f"{HealthCheckName.CHECK_SENSORS.value} is disabled by killswitch."
+
+
+def test_killswitch_disabled_continues() -> None:
+    """When killswitch_getter returns False, the with block body should execute normally."""
     body_executed = False
     with _make_runtime(killswitch_getter=lambda: False) as rt:
         body_executed = True
@@ -110,24 +121,8 @@ def test_killswitch_disabled_continues(
     assert body_executed
 
 
-@patch(
-    "gcm.health_checks.check_utils.runtime.get_derived_cluster",
-    return_value="test_cluster",
-)
-@patch("gcm.health_checks.check_utils.runtime.gni_lib")
-@patch("gcm.health_checks.check_utils.runtime.init_logger")
-@patch("gcm.health_checks.check_utils.runtime.socket")
-def test_finish_sets_code_and_exits(
-    mock_socket: MagicMock,
-    mock_init_logger: MagicMock,
-    mock_gni: MagicMock,
-    mock_derived: MagicMock,
-) -> None:
+def test_finish_sets_code_and_exits() -> None:
     """finish() should set exit_code and msg, then call sys.exit with the code value."""
-    mock_socket.gethostname.return_value = "testnode01"
-    mock_init_logger.return_value = (logging.getLogger("test"), MagicMock())
-    mock_gni.get_gpu_node_id.return_value = "gpu-0"
-
     with pytest.raises(SystemExit) as exc_info:
         with _make_runtime() as rt:
             rt.finish(ExitCode.CRITICAL, "something broke")
@@ -137,59 +132,32 @@ def test_finish_sets_code_and_exits(
     assert rt.msg == "something broke"
 
 
-@patch("gcm.health_checks.check_utils.runtime.OutputContext")
-@patch("gcm.health_checks.check_utils.runtime.TelemetryContext")
-@patch(
-    "gcm.health_checks.check_utils.runtime.get_derived_cluster",
-    return_value="test_cluster",
-)
-@patch("gcm.health_checks.check_utils.runtime.gni_lib")
-@patch("gcm.health_checks.check_utils.runtime.init_logger")
-@patch("gcm.health_checks.check_utils.runtime.socket")
-def test_telemetry_and_output_contexts_entered(
-    mock_socket: MagicMock,
-    mock_init_logger: MagicMock,
-    mock_gni: MagicMock,
-    mock_derived: MagicMock,
-    mock_telemetry_cls: MagicMock,
-    mock_output_cls: MagicMock,
-) -> None:
+def test_telemetry_and_output_contexts_entered() -> None:
     """Both TelemetryContext and OutputContext should be entered during __enter__."""
-    mock_socket.gethostname.return_value = "testnode01"
-    mock_init_logger.return_value = (logging.getLogger("test"), MagicMock())
-    mock_gni.get_gpu_node_id.return_value = "gpu-0"
-
+    mock_telem_cls = MagicMock()
     mock_telem_instance = MagicMock()
-    mock_telemetry_cls.return_value = mock_telem_instance
+    mock_telem_cls.return_value = mock_telem_instance
+
+    mock_output_cls = MagicMock()
     mock_output_instance = MagicMock()
     mock_output_cls.return_value = mock_output_instance
 
-    with _make_runtime() as rt:
+    with _make_runtime(
+        telemetry_context_factory=mock_telem_cls,
+        output_context_factory=mock_output_cls,
+    ) as rt:
         rt.exit_code = ExitCode.OK
 
     mock_telem_instance.__enter__.assert_called_once()
     mock_output_instance.__enter__.assert_called_once()
 
 
-@patch(
-    "gcm.health_checks.check_utils.runtime.get_derived_cluster",
-    return_value="test_cluster",
-)
-@patch("gcm.health_checks.check_utils.runtime.gni_lib")
-@patch("gcm.health_checks.check_utils.runtime.init_logger")
-@patch("gcm.health_checks.check_utils.runtime.socket")
-def test_gpu_node_id_failure_handled(
-    mock_socket: MagicMock,
-    mock_init_logger: MagicMock,
-    mock_gni: MagicMock,
-    mock_derived: MagicMock,
-) -> None:
-    """When gni_lib.get_gpu_node_id raises, gpu_node_id should be None and a warning logged."""
-    mock_socket.gethostname.return_value = "testnode01"
-    test_logger = logging.getLogger("test_gpu_failure")
-    mock_init_logger.return_value = (test_logger, MagicMock())
-    mock_gni.get_gpu_node_id.side_effect = RuntimeError("not a GPU host")
+def test_gpu_node_id_failure_handled() -> None:
+    """When get_gpu_node_id raises, gpu_node_id should be None."""
 
-    with _make_runtime() as rt:
+    def failing_gpu_node_id() -> str:
+        raise RuntimeError("not a GPU host")
+
+    with _make_runtime(get_gpu_node_id=failing_gpu_node_id) as rt:
         assert rt.gpu_node_id is None
         rt.exit_code = ExitCode.OK


### PR DESCRIPTION
## Summary

Ref: #75

- Introduce `HealthCheckRuntime`, a `@dataclass` context manager that encapsulates the ~30 lines of repeated setup code every health check subcommand duplicates: logger initialization, GPU node ID detection, derived cluster resolution, `ExitStack` with `TelemetryContext` + `OutputContext`, and killswitch checking
- Reduces per-subcommand boilerplate from ~30 lines to ~5 lines (a `with HealthCheckRuntime(...) as rt:` block)
- Purely additive — existing checks continue to work unchanged; no migration in this PR

**Stacked PR series**: [1/2] Runtime helper → [2/2] Scaffold tool (depends on this PR)

### Before (~30 lines per subcommand)
```python
node = socket.gethostname()
logger, _ = init_logger(...)
try: gpu_node_id = gni_lib.get_gpu_node_id()
except: gpu_node_id = None; ...
derived_cluster = get_derived_cluster(...)
exit_code = ExitCode.UNKNOWN
msg = ""
with ExitStack() as s:
    s.enter_context(TelemetryContext(...))
    s.enter_context(OutputContext(...))
    ff = FeatureValueHealthChecksFeatures()
    if ff.get_healthchecksfeatures_disable_check_sensors():
        exit_code = ExitCode.OK; ...
    # actual check logic
    sys.exit(exit_code.value)
```

### After (~5 lines per subcommand)
```python
with HealthCheckRuntime(
    cluster=cluster, type=type, log_level=log_level,
    log_folder=log_folder, sink=sink, sink_opts=sink_opts,
    verbose_out=verbose_out,
    heterogeneous_cluster_v1=heterogeneous_cluster_v1,
    health_check_name=HealthCheckName.CHECK_SENSORS,
    killswitch_getter=lambda: FeatureValueHealthChecksFeatures()
        .get_healthchecksfeatures_disable_check_sensors(),
) as rt:
    # actual check logic using rt.logger, rt.node, etc.
    rt.finish(exit_code, msg)
```

## Test plan
- [ ] `nox -s tests -- gcm/tests/health_checks_tests/test_runtime.py` — 6 tests covering initialization, killswitch behavior, finish(), context nesting, GPU node ID failure
- [ ] `nox -s lint`
- [ ] `nox -s format`
- [ ] `nox -s typecheck`