### PR TITLE
Fix ExitCode.UNKNOWN typo in health checks onboarding docs

### DIFF
--- a/gcm/docs/health_checks_onboarding.md
+++ b/gcm/docs/health_checks_onboarding.md
@@ -126,7 +126,7 @@ The next code snippet shows the beginning of the check. This boiler plate code i
     if obj is None: # <-- during normal invocation this is None. It is not None when called from our unit tests.
         obj = StorageCheckImpl(cluster, type, log_level, log_folder)
 
-    overall_exit_code = ExitCode.UNKNOW # <-- initialize the exit code and messages to be returned
+    overall_exit_code = ExitCode.UNKNOWN # <-- initialize the exit code and messages to be returned
     overall_msg = ""
 ```
 


### PR DESCRIPTION
## Summary

This PR fixes a minor typo in the onboarding documentation where ExitCode.UNKNOW was used instead of ExitCode.UNKNOWN. Not sure if this is PR worthy, but throwing it up regardless.

Change: updated one line in `health_checks_onboarding.md:129`.

## Test Plan

Documentation-only change; no runtime impact.
