### PR TITLE
Add check_aws_events health_checks plugin (IMDSv2 maintenance event poll) (#139)

### DIFF
--- a/gcm/health_checks/checks/__init__.py
+++ b/gcm/health_checks/checks/__init__.py
@@ -2,6 +2,7 @@
 # All rights reserved.
 from gcm.health_checks.checks.check_airstore import check_airstore
 from gcm.health_checks.checks.check_authentication import check_authentication
+from gcm.health_checks.checks.check_aws_events import check_aws_events
 from gcm.health_checks.checks.check_blockdev import check_blockdev
 from gcm.health_checks.checks.check_dcgmi import check_dcgmi
 from gcm.health_checks.checks.check_ethlink import check_ethlink
@@ -39,6 +40,7 @@ __all__ = [
     "check_service",
     "check_ib",
     "check_authentication",
+    "check_aws_events",
     "check_node",
     "check_pci",
     "check_blockdev",

--- a/gcm/health_checks/checks/check_aws_events.py
+++ b/gcm/health_checks/checks/check_aws_events.py
@@ -1,0 +1,179 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+import json
+from typing import Callable, Collection, Optional, Tuple
+
+import click
+import requests
+from gcm.health_checks.check_utils.runtime import HealthCheckRuntime
+from gcm.health_checks.click import (
+    common_arguments,
+    telemetry_argument,
+    timeout_argument,
+)
+from gcm.health_checks.types import CHECK_TYPE, ExitCode, LOG_LEVEL
+from gcm.monitoring.click import heterogeneous_cluster_v1_option
+from gcm.monitoring.features.gen.generated_features_healthchecksfeatures import (
+    FeatureValueHealthChecksFeatures,
+)
+from gcm.schemas.health_check.health_check_name import HealthCheckName
+from typeguard import typechecked
+
+# Conservative bias: any IMDS error (off-EC2, network blip, IMDS misconfigured)
+# returns ExitCode.OK so we never false-alarm the entire fleet on a transient
+# IMDS outage — a real fleet-wide IMDS outage is its own incident, and
+# falsely flipping every node would trigger fleet-wide drains via NLC.
+#
+# AWS endpoint reference:
+#   https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-instances-status-check_sched.html#viewing_scheduled_events
+
+DEFAULT_IMDS_BASE_URL = "http://169.254.169.254"
+DEFAULT_IMDS_TIMEOUT_SECS = 3
+DEFAULT_TOKEN_TTL_SECS = 60
+
+# IMDS is link-local (169.254.169.254) and must NEVER be reached through an
+# HTTP proxy. If a node ever inherits HTTP_PROXY / HTTPS_PROXY env vars, the
+# default `requests` behavior of honoring them would route every node's IMDS
+# query at the proxy server's metadata — and a single retirement event on the
+# proxy host would fan out into a fleet-wide drain. Always pass an explicit
+# empty proxies dict to bypass env-based proxy resolution for these calls.
+_NO_PROXY: dict[str, str] = {"http": "", "https": ""}
+
+FnFetchToken = Callable[[str, int, int], Optional[str]]
+FnFetchEvents = Callable[[str, str, int], Tuple[ExitCode, str]]
+ImdsFetchers = Tuple[FnFetchToken, FnFetchEvents]
+
+
+def fetch_imds_token(
+    base_url: str, ttl_seconds: int, timeout_secs: int
+) -> Optional[str]:
+    """Mint an IMDSv2 session token. Returns None on any transport or HTTP
+    error (or empty body) so the caller can short-circuit to a healthy
+    result."""
+    try:
+        resp = requests.put(
+            f"{base_url.rstrip('/')}/latest/api/token",
+            headers={"X-aws-ec2-metadata-token-ttl-seconds": str(ttl_seconds)},
+            timeout=timeout_secs,
+            proxies=_NO_PROXY,
+        )
+        resp.raise_for_status()
+    except requests.RequestException:
+        return None
+    return resp.text or None
+
+
+def fetch_scheduled_events(
+    base_url: str, token: str, timeout_secs: int
+) -> Tuple[ExitCode, str]:
+    """GET the IMDS scheduled-events endpoint and translate the response into
+    an exit code. Returns OK for the no-events / unreachable / malformed
+    cases (don't false-alarm the fleet) and WARN with a one-line summary
+    for the pending-event case."""
+    url = f"{base_url.rstrip('/')}/latest/meta-data/events/maintenance/scheduled"
+    try:
+        resp = requests.get(
+            url,
+            headers={"X-aws-ec2-metadata-token": token},
+            timeout=timeout_secs,
+            proxies=_NO_PROXY,
+        )
+    except requests.RequestException:
+        return ExitCode.OK, "IMDS events endpoint unreachable; skipping check"
+
+    if resp.status_code == 404:
+        return ExitCode.OK, "No pending AWS maintenance events"
+    if resp.status_code != 200:
+        return ExitCode.OK, (
+            f"Unexpected HTTP {resp.status_code} from IMDS; skipping check"
+        )
+
+    body = resp.text.strip()
+    if not body or body == "[]":
+        return ExitCode.OK, "No pending AWS maintenance events"
+    try:
+        events = json.loads(body)
+    except json.JSONDecodeError:
+        return ExitCode.OK, "Failed to decode IMDS event payload; skipping check"
+    # Validate payload shape — IMDS is documented to return a JSON array of
+    # event objects, but a misbehaving proxy / mitm / future API change could
+    # return something else. Treat any unexpected shape as healthy rather
+    # than crashing on `events[0]` (which would exit 1 == ExitCode.WARN ==
+    # fleet-wide drain trigger).
+    if not isinstance(events, list):
+        return ExitCode.OK, "Unexpected IMDS payload (not a list); skipping check"
+    if not events:
+        return ExitCode.OK, "No pending AWS maintenance events"
+    head = events[0]
+    if not isinstance(head, dict):
+        return ExitCode.OK, "Unexpected IMDS event item (not a dict); skipping check"
+
+    summary = (
+        f"{head.get('Code', 'unknown')} "
+        f"NotBefore={head.get('NotBefore', 'unknown')} "
+        f"State={head.get('State', 'unknown')} "
+        f"EventId={head.get('EventId', 'unknown')}"
+    )
+    return ExitCode.WARN, f"AWS maintenance pending ({len(events)} event(s)): {summary}"
+
+
+@click.command()
+@common_arguments
+@timeout_argument
+@telemetry_argument
+@heterogeneous_cluster_v1_option
+@click.option(
+    "--imds-base-url",
+    type=str,
+    default=DEFAULT_IMDS_BASE_URL,
+    help="IMDS base URL. Override only for testing.",
+)
+@click.option(
+    "--imds-timeout",
+    type=int,
+    default=DEFAULT_IMDS_TIMEOUT_SECS,
+    help="Per-call HTTP timeout in seconds for IMDS requests.",
+)
+@click.pass_obj
+@typechecked
+def check_aws_events(
+    obj: Optional[ImdsFetchers],
+    cluster: str,
+    type: CHECK_TYPE,
+    log_level: LOG_LEVEL,
+    log_folder: str,
+    timeout: int,
+    sink: str,
+    sink_opts: Collection[str],
+    verbose_out: bool,
+    heterogeneous_cluster_v1: bool,
+    imds_base_url: str,
+    imds_timeout: int,
+) -> None:
+    """Check for pending AWS scheduled maintenance / instance retirement
+    events on this EC2 instance via IMDSv2. Exits non-zero with a
+    one-line summary when any event is pending; exits 0 (healthy) on
+    no-events, IMDS unreachable, or any other transport error to avoid
+    false-alarming the fleet."""
+    fetch_token, fetch_events = (
+        (fetch_imds_token, fetch_scheduled_events) if obj is None else obj
+    )
+
+    with HealthCheckRuntime(
+        cluster=cluster,
+        check_type=type,
+        log_level=log_level,
+        log_folder=log_folder,
+        sink=sink,
+        sink_opts=sink_opts,
+        verbose_out=verbose_out,
+        heterogeneous_cluster_v1=heterogeneous_cluster_v1,
+        health_check_name=HealthCheckName.CHECK_AWS_EVENTS,
+        killswitch_getter=lambda: FeatureValueHealthChecksFeatures().get_healthchecksfeatures_disable_check_aws_events(),
+    ) as rt:
+        token = fetch_token(imds_base_url, DEFAULT_TOKEN_TTL_SECS, imds_timeout)
+        if token is None:
+            rt.finish(ExitCode.OK, "IMDS token unreachable; skipping check")
+
+        exit_code, msg = fetch_events(imds_base_url, token, imds_timeout)
+        rt.finish(exit_code, msg)

--- a/gcm/health_checks/cli/health_checks.py
+++ b/gcm/health_checks/cli/health_checks.py
@@ -48,6 +48,7 @@ list_of_checks: List[click.core.Command] = [
     checks.check_service,
     checks.check_ib,
     checks.check_authentication,
+    checks.check_aws_events,
     checks.check_node,
     checks.check_pci,
     checks.check_blockdev,

--- a/gcm/monitoring/features/feature_definitions/health_checks_features.py
+++ b/gcm/monitoring/features/feature_definitions/health_checks_features.py
@@ -63,3 +63,4 @@ class HealthChecksFeatures:
     disable_check_clocksource: bool
     disable_airstore_credential_count: bool
     disable_check_sensors: bool
+    disable_check_aws_events: bool

--- a/gcm/monitoring/features/gen/generated_features_healthchecksfeatures.py
+++ b/gcm/monitoring/features/gen/generated_features_healthchecksfeatures.py
@@ -898,3 +898,17 @@ class FeatureValueHealthChecksFeatures:
                 f"Expected bool value for HealthChecksFeatures.disable_check_sensors, got {type(value).__name__} instead."
             )
         return value
+
+    def get_healthchecksfeatures_disable_check_aws_events(self) -> bool:
+        try:
+            features = self.load_config()
+        except Exception:
+            return False
+        value = features.get("HealthChecksFeatures", {}).get(
+            "disable_check_aws_events", False
+        )
+        if not isinstance(value, bool):
+            raise TypeError(
+                f"Expected bool value for HealthChecksFeatures.disable_check_aws_events, got {type(value).__name__} instead."
+            )
+        return value

--- a/gcm/schemas/health_check/health_check_name.py
+++ b/gcm/schemas/health_check/health_check_name.py
@@ -66,3 +66,4 @@ class HealthCheckName(Enum):
     CHECK_ETHLINK = "check ethlink"
     CHECK_CLOCKSOURCE = "check clocksource"
     CHECK_SENSORS = "check sensors"
+    CHECK_AWS_EVENTS = "check aws events"

--- a/gcm/tests/health_checks_tests/test_check_aws_events.py
+++ b/gcm/tests/health_checks_tests/test_check_aws_events.py
@@ -1,0 +1,247 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+import json
+import logging
+from pathlib import Path
+from typing import NoReturn, Tuple
+
+import pytest
+import requests
+import requests_mock as rm
+from click.testing import CliRunner
+from gcm.health_checks.checks.check_aws_events import (
+    check_aws_events,
+    fetch_imds_token,
+    fetch_scheduled_events,
+)
+from gcm.health_checks.types import ExitCode
+
+IMDS = "http://imds.test"  # any non-link-local URL works with requests_mock
+TOKEN_URL = f"{IMDS}/latest/api/token"
+EVENTS_URL = f"{IMDS}/latest/meta-data/events/maintenance/scheduled"
+
+# A canonical AWS scheduled-events response (one pending instance retirement).
+# Source: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-instances-status-check_sched.html
+SAMPLE_EVENTS = [
+    {
+        "Code": "instance-retirement",
+        "Description": "The instance is scheduled for retirement",
+        "EventId": "instance-event-0123abcd",
+        "NotBefore": "2026-05-12T03:00:00Z",
+        "NotAfter": "2026-05-12T04:00:00Z",
+        "State": "active",
+    }
+]
+
+
+def test_fetch_imds_token_success() -> None:
+    with rm.Mocker() as m:
+        m.put(TOKEN_URL, text="FAKE-TOKEN")
+        token = fetch_imds_token(IMDS, ttl_seconds=60, timeout_secs=3)
+    assert token == "FAKE-TOKEN"
+
+
+def test_fetch_imds_token_off_ec2_returns_none() -> None:
+    with rm.Mocker() as m:
+        m.put(TOKEN_URL, exc=requests.ConnectionError)
+        token = fetch_imds_token(IMDS, ttl_seconds=60, timeout_secs=3)
+    assert token is None
+
+
+def test_fetch_imds_token_500_returns_none() -> None:
+    with rm.Mocker() as m:
+        m.put(TOKEN_URL, status_code=500, text="boom")
+        token = fetch_imds_token(IMDS, ttl_seconds=60, timeout_secs=3)
+    assert token is None
+
+
+def test_fetch_imds_token_empty_body_returns_none() -> None:
+    """A 200 with an empty body should be treated as 'no token' so we
+    short-circuit to OK rather than sending an empty Authorization header."""
+    with rm.Mocker() as m:
+        m.put(TOKEN_URL, status_code=200, text="")
+        token = fetch_imds_token(IMDS, ttl_seconds=60, timeout_secs=3)
+    assert token is None
+
+
+def test_fetch_imds_token_strips_trailing_slash_in_base_url() -> None:
+    with rm.Mocker() as m:
+        m.put(TOKEN_URL, text="FAKE-TOKEN")
+        token = fetch_imds_token(f"{IMDS}/", ttl_seconds=60, timeout_secs=3)
+    assert token == "FAKE-TOKEN"
+
+
+def test_fetch_imds_token_bypasses_http_proxy() -> None:
+    """IMDS is link-local and must never be reached through a proxy. Verify
+    the request was sent with proxies={} so requests doesn't honor
+    HTTP_PROXY env vars."""
+    with rm.Mocker() as m:
+        m.put(TOKEN_URL, text="FAKE-TOKEN")
+        fetch_imds_token(IMDS, ttl_seconds=60, timeout_secs=3)
+        last = m.last_request
+    assert last is not None
+    # requests-mock exposes proxies via the prepared request when explicitly
+    # set; verify the call did not fall back to env-based proxy resolution.
+    assert last.proxies == {"http": "", "https": ""}
+
+
+def test_fetch_events_no_pending_returns_ok() -> None:
+    """200 + empty array is the documented "no events" response."""
+    with rm.Mocker() as m:
+        m.get(EVENTS_URL, status_code=200, text="[]")
+        code, msg = fetch_scheduled_events(IMDS, "tok", timeout_secs=3)
+    assert code == ExitCode.OK
+    assert "No pending AWS maintenance events" in msg
+
+
+def test_fetch_events_404_returns_ok() -> None:
+    """404 on the endpoint is also a valid "no events" signal."""
+    with rm.Mocker() as m:
+        m.get(EVENTS_URL, status_code=404)
+        code, msg = fetch_scheduled_events(IMDS, "tok", timeout_secs=3)
+    assert code == ExitCode.OK
+    assert "No pending AWS maintenance events" in msg
+
+
+def test_fetch_events_one_pending_returns_warn_with_summary() -> None:
+    with rm.Mocker() as m:
+        m.get(EVENTS_URL, status_code=200, text=json.dumps(SAMPLE_EVENTS))
+        code, msg = fetch_scheduled_events(IMDS, "tok", timeout_secs=3)
+    assert code == ExitCode.WARN
+    assert "AWS maintenance pending (1 event(s))" in msg
+    assert "instance-retirement" in msg
+    assert "NotBefore=2026-05-12T03:00:00Z" in msg
+    assert "EventId=instance-event-0123abcd" in msg
+    assert "State=active" in msg
+
+
+def test_fetch_events_multiple_pending_reports_count() -> None:
+    events = SAMPLE_EVENTS + [
+        {
+            "Code": "system-reboot",
+            "EventId": "instance-event-deadbeef",
+            "NotBefore": "2026-06-01T00:00:00Z",
+            "State": "active",
+        }
+    ]
+    with rm.Mocker() as m:
+        m.get(EVENTS_URL, status_code=200, text=json.dumps(events))
+        code, msg = fetch_scheduled_events(IMDS, "tok", timeout_secs=3)
+    assert code == ExitCode.WARN
+    assert "AWS maintenance pending (2 event(s))" in msg
+
+
+def test_fetch_events_unreachable_returns_ok() -> None:
+    """Don't false-alarm the fleet on a transient IMDS network error."""
+    with rm.Mocker() as m:
+        m.get(EVENTS_URL, exc=requests.ConnectionError)
+        code, msg = fetch_scheduled_events(IMDS, "tok", timeout_secs=3)
+    assert code == ExitCode.OK
+    assert "skipping check" in msg
+
+
+def test_fetch_events_unexpected_5xx_returns_ok() -> None:
+    with rm.Mocker() as m:
+        m.get(EVENTS_URL, status_code=503, text="boom")
+        code, msg = fetch_scheduled_events(IMDS, "tok", timeout_secs=3)
+    assert code == ExitCode.OK
+    assert "Unexpected HTTP 503" in msg
+
+
+def test_fetch_events_garbage_body_returns_ok() -> None:
+    """Malformed JSON shouldn't false-alarm — drop and skip."""
+    with rm.Mocker() as m:
+        m.get(EVENTS_URL, status_code=200, text="not-json{")
+        code, msg = fetch_scheduled_events(IMDS, "tok", timeout_secs=3)
+    assert code == ExitCode.OK
+    assert "Failed to decode IMDS event payload" in msg
+
+
+def test_fetch_events_non_list_payload_returns_ok() -> None:
+    """Valid JSON of the wrong shape (dict instead of list) must not
+    crash on `events[0]`; would otherwise exit 1 == fleet-wide drain."""
+    with rm.Mocker() as m:
+        m.get(EVENTS_URL, status_code=200, text=json.dumps({"error": "Forbidden"}))
+        code, msg = fetch_scheduled_events(IMDS, "tok", timeout_secs=3)
+    assert code == ExitCode.OK
+    assert "not a list" in msg
+
+
+def test_fetch_events_non_dict_item_returns_ok() -> None:
+    """List of scalars (a misbehaving proxy or future API shape) must not
+    crash on head.get(...); would otherwise exit 1 == fleet-wide drain."""
+    with rm.Mocker() as m:
+        m.get(EVENTS_URL, status_code=200, text=json.dumps([42, "scheduled"]))
+        code, msg = fetch_scheduled_events(IMDS, "tok", timeout_secs=3)
+    assert code == ExitCode.OK
+    assert "not a dict" in msg
+
+
+def test_fetch_events_strips_trailing_slash_in_base_url() -> None:
+    with rm.Mocker() as m:
+        m.get(EVENTS_URL, status_code=404)
+        code, _ = fetch_scheduled_events(f"{IMDS}/", "tok", timeout_secs=3)
+    assert code == ExitCode.OK
+
+
+def test_fetch_events_bypasses_http_proxy() -> None:
+    with rm.Mocker() as m:
+        m.get(EVENTS_URL, status_code=404)
+        fetch_scheduled_events(IMDS, "tok", timeout_secs=3)
+        last = m.last_request
+    assert last is not None
+    assert last.proxies == {"http": "", "https": ""}
+
+
+def test_check_aws_events_off_ec2_exits_ok(
+    caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """End-to-end: on an off-EC2 host (no token), the Click command exits 0
+    with a skipped-check message — never false-alarms."""
+    runner = CliRunner(mix_stderr=False)
+    caplog.at_level(logging.INFO)
+
+    def fake_fetch_token(_url: str, _ttl: int, _timeout: int) -> None:
+        return None
+
+    def fake_fetch_events(_url: str, _token: str, _timeout: int) -> NoReturn:
+        raise AssertionError("should not be called when token is None")
+
+    result = runner.invoke(
+        check_aws_events,
+        f"test-cluster prolog --log-folder={tmp_path} --sink=do_nothing",
+        obj=(fake_fetch_token, fake_fetch_events),
+    )
+    assert result.exit_code == ExitCode.OK.value
+    assert "IMDS token unreachable; skipping check" in caplog.text
+
+
+def test_check_aws_events_pending_event_exits_warn(
+    caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """End-to-end: with a real event payload, the Click command exits WARN
+    and the summary makes it into the log (which becomes the NPD condition
+    message)."""
+    runner = CliRunner(mix_stderr=False)
+    caplog.at_level(logging.INFO)
+
+    def fake_fetch_token(_url: str, _ttl: int, _timeout: int) -> str:
+        return "tok"
+
+    def fake_fetch_events(
+        _url: str, _token: str, _timeout: int
+    ) -> Tuple[ExitCode, str]:
+        return ExitCode.WARN, (
+            "AWS maintenance pending (1 event(s)): instance-retirement "
+            "NotBefore=2026-05-12T03:00:00Z State=active "
+            "EventId=instance-event-0123abcd"
+        )
+
+    result = runner.invoke(
+        check_aws_events,
+        f"test-cluster prolog --log-folder={tmp_path} --sink=do_nothing",
+        obj=(fake_fetch_token, fake_fetch_events),
+    )
+    assert result.exit_code == ExitCode.WARN.value
+    assert "AWS maintenance pending" in caplog.text
+    assert "instance-retirement" in caplog.text

--- a/gcm/tests/health_checks_tests/test_killswitches.py
+++ b/gcm/tests/health_checks_tests/test_killswitches.py
@@ -77,6 +77,7 @@ def _write_to_file(path: Path, data: str) -> Path:
         "check-node check-module -m sth",
         "check-node check-dnf-repos",
         "check-sensors",
+        "check-aws-events",
     ],
 )
 @typechecked
@@ -134,6 +135,7 @@ def test_killswitches(
         disable_check_module = true
         disable_check_dnf_repos = true
         disable_check_sensors = true
+        disable_check_aws_events = true
         """,
     )
 

--- a/website/docs/GCM_Health_Checks/health_checks/check-aws-events.md
+++ b/website/docs/GCM_Health_Checks/health_checks/check-aws-events.md
@@ -1,0 +1,63 @@
+# check-aws-events
+
+## Overview
+Polls the EC2 Instance Metadata Service (IMDSv2) `/latest/meta-data/events/maintenance/scheduled` endpoint for pending AWS maintenance or instance-retirement events scheduled against the local node. Surfaces them as a node condition (via NPD's exit-code translation) so operators can drain, cordon, or replace the instance ahead of AWS's enforced `NotBefore` timestamp rather than letting workloads be killed when AWS rotates the host.
+
+The check is conservatively biased toward `OK`: any transport error, off-EC2 condition, non-2xx response, or malformed payload returns `ExitCode.OK` so a transient IMDS blip can never trigger a fleet-wide drain. Only a `200` response with a non-empty events array exits `WARN`.
+
+## Requirements
+
+- **EC2 instance**: The check only produces a meaningful result on AWS EC2 hosts. Off-EC2 (no IMDS), it exits `OK` with a "skipping check" message.
+- **IMDSv2 reachable**: The link-local address `169.254.169.254` must be routable from the node. Any HTTP proxy env vars (`HTTP_PROXY`, `HTTPS_PROXY`) are explicitly bypassed for IMDS calls.
+
+## Command-Line Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--imds-base-url` | String | `http://169.254.169.254` | IMDS base URL. Override only for testing. |
+| `--imds-timeout` | Integer | 3 | Per-call HTTP timeout in seconds for IMDS requests. |
+| `--timeout` | Integer | 300 | Command execution timeout in seconds |
+| `--sink` | String | do_nothing | Telemetry sink destination |
+| `--sink-opt` / `-o` | Multiple | - | Sink-specific configuration (OmegaConf dot-list syntax) |
+| `--verbose-out` | Flag | False | Display detailed output |
+| `--log-level` | Choice | INFO | DEBUG, INFO, WARNING, ERROR, CRITICAL |
+| `--log-folder` | String | `healthchecks` | Log directory |
+| `--heterogeneous-cluster-v1` | Flag | False | Enable heterogeneous cluster support |
+
+## Exit Conditions
+
+| Exit Code | Condition |
+|-----------|-----------|
+| **OK (0)** | Feature flag `disable_check_aws_events` set (killswitch active) |
+| **OK (0)** | No pending AWS maintenance events |
+| **OK (0)** | IMDS token endpoint unreachable (off-EC2 or network blip) |
+| **OK (0)** | IMDS events endpoint unreachable, returned non-200/404, or returned a malformed/non-list payload |
+| **WARN (1)** | One or more pending maintenance events; message includes `Code NotBefore=... State=... EventId=...` for the first event |
+| **UNKNOWN (3)** | Unexpected error before parsing |
+
+## Usage Examples
+
+### Basic Check
+```shell
+health_checks check-aws-events [CLUSTER] app
+```
+
+### With Telemetry
+```shell
+health_checks check-aws-events \
+  --sink otel \
+  --sink-opt "log_resource_attributes={'attr_1': 'value1'}" \
+  [CLUSTER] \
+  app
+```
+
+### Debug Mode (point at a local fake IMDS)
+```shell
+health_checks check-aws-events \
+  --imds-base-url http://127.0.0.1:9999 \
+  --log-level DEBUG \
+  --verbose-out \
+  --sink stdout \
+  [CLUSTER] \
+  app
+```


### PR DESCRIPTION
Summary:

Adds `check-aws-events`, a new GCM `health_checks` Click subcommand that polls EC2 IMDSv2 (`/latest/meta-data/events/maintenance/scheduled`) for pending instance maintenance / retirement events scheduled against the local node. Surfaces them as a node condition via NPD's exit-code translation so operators can drain / cordon / replace the instance ahead of AWS's enforced `NotBefore` rather than letting workloads be killed when AWS rotates the host.

Endpoint, method, and headers match the AWS IMDSv2 spec used by `aws-node-termination-handler` for the scheduled-events endpoint (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-instances-status-check_sched.html#viewing_scheduled_events). Conservative fail-safe semantics: any transport / unreachable / non-list / non-dict / malformed-payload response returns `ExitCode.OK` so a transient IMDS blip can never trigger a fleet-wide drain. Only a `200 + non-empty events array` exits `WARN` with a one-line summary (`Code NotBefore=... State=... EventId=...`), which NPD records as the condition message.

Files:
- `gcm/health_checks/checks/check_aws_events.py` (new) — Click subcommand + two helpers (`fetch_imds_token`, `fetch_scheduled_events`) that the test suite injects fakes for via `click.pass_obj`. Always passes `proxies={"http": "", "https": ""}` so `requests` never honors `HTTP_PROXY` and accidentally routes IMDS at a proxy server's metadata.
- `gcm/health_checks/checks/__init__.py` + `gcm/health_checks/cli/health_checks.py` — register.
- `gcm/schemas/health_check/health_check_name.py` — new `HealthCheckName.CHECK_AWS_EVENTS = "check aws events"` for telemetry.
- `gcm/tests/health_checks_tests/test_check_aws_events.py` (new) — 19 tests covering token fetch (happy / off-EC2 / 5xx / empty body / proxies bypass / trailing-slash), events response (200-empty / 404 / one-pending / multi-pending / non-list / non-dict / unreachable / 5xx / garbage / proxies bypass / trailing-slash), and full Click command exit codes (off-EC2 → OK, pending → WARN with summary).
- `BUCK` — add `requests` to `:health_checks` library deps and `requests` + `requests-mock` to `:health_checks_pytest`.

Differential Revision: D104060213


