### PR TITLE
[GCM] Add schedule_exit and bf_exit sdiag counters to slurm monitor

### DIFF
--- a/gcm/monitoring/slurm/client.py
+++ b/gcm/monitoring/slurm/client.py
@@ -199,6 +199,8 @@ class SlurmCliClient(SlurmClient):
                 subprocess.check_output(["sdiag", "--all", "--json"], text=True)
             )
             stats = sdiag_output["statistics"]
+            schedule_exit = stats.get("schedule_exit") or {}
+            bf_exit = stats.get("bf_exit") or {}
 
             result = Sdiag(
                 server_thread_count=stats.get("server_thread_count"),
@@ -224,6 +226,20 @@ class SlurmCliClient(SlurmClient):
                 bf_cycle_sum=stats.get("bf_cycle_sum"),
                 bf_cycle_max=stats.get("bf_cycle_max"),
                 bf_queue_len=stats.get("bf_queue_len"),
+                schedule_exit_end_job_queue=schedule_exit.get("end_job_queue"),
+                schedule_exit_default_queue_depth=schedule_exit.get(
+                    "default_queue_depth"
+                ),
+                schedule_exit_max_job_start=schedule_exit.get("max_job_start"),
+                schedule_exit_max_rpc_cnt=schedule_exit.get("max_rpc_cnt"),
+                schedule_exit_max_sched_time=schedule_exit.get("max_sched_time"),
+                schedule_exit_licenses=schedule_exit.get("licenses"),
+                bf_exit_end_job_queue=bf_exit.get("end_job_queue"),
+                bf_exit_max_job_start=bf_exit.get("bf_max_job_start"),
+                bf_exit_max_job_test=bf_exit.get("bf_max_job_test"),
+                bf_exit_max_time=bf_exit.get("bf_max_time"),
+                bf_exit_node_space_size=bf_exit.get("bf_node_space_size"),
+                bf_exit_state_changed=bf_exit.get("state_changed"),
             )
 
             # Reset sdiag counters after collection

--- a/gcm/monitoring/slurm/rest_client.py
+++ b/gcm/monitoring/slurm/rest_client.py
@@ -113,6 +113,8 @@ class SlurmRestClient(SlurmClient):
     def sdiag_structured(self) -> Sdiag:
         data = self._get(f"/slurm/{self.api_version}/diag")
         stats = data.get("statistics", {})
+        schedule_exit = stats.get("schedule_exit") or {}
+        bf_exit = stats.get("bf_exit") or {}
         result = Sdiag(
             server_thread_count=stats.get("server_thread_count"),
             agent_queue_size=stats.get("agent_queue_size"),
@@ -137,6 +139,18 @@ class SlurmRestClient(SlurmClient):
             bf_cycle_sum=stats.get("bf_cycle_sum"),
             bf_cycle_max=stats.get("bf_cycle_max"),
             bf_queue_len=stats.get("bf_queue_len"),
+            schedule_exit_end_job_queue=schedule_exit.get("end_job_queue"),
+            schedule_exit_default_queue_depth=schedule_exit.get("default_queue_depth"),
+            schedule_exit_max_job_start=schedule_exit.get("max_job_start"),
+            schedule_exit_max_rpc_cnt=schedule_exit.get("max_rpc_cnt"),
+            schedule_exit_max_sched_time=schedule_exit.get("max_sched_time"),
+            schedule_exit_licenses=schedule_exit.get("licenses"),
+            bf_exit_end_job_queue=bf_exit.get("end_job_queue"),
+            bf_exit_max_job_start=bf_exit.get("bf_max_job_start"),
+            bf_exit_max_job_test=bf_exit.get("bf_max_job_test"),
+            bf_exit_max_time=bf_exit.get("bf_max_time"),
+            bf_exit_node_space_size=bf_exit.get("bf_node_space_size"),
+            bf_exit_state_changed=bf_exit.get("state_changed"),
         )
         return result
 

--- a/gcm/monitoring/slurm/rest_client.py
+++ b/gcm/monitoring/slurm/rest_client.py
@@ -113,6 +113,8 @@ class SlurmRestClient(SlurmClient):
     def sdiag_structured(self) -> Sdiag:
         data = self._get(f"/slurm/{self.api_version}/diag")
         stats = data.get("statistics", {})
+        schedule_exit = stats.get("schedule_exit") or {}
+        bf_exit = stats.get("bf_exit") or {}
         result = Sdiag(
             server_thread_count=stats.get("server_thread_count"),
             agent_queue_size=stats.get("agent_queue_size"),
@@ -137,6 +139,20 @@ class SlurmRestClient(SlurmClient):
             bf_cycle_sum=stats.get("bf_cycle_sum"),
             bf_cycle_max=stats.get("bf_cycle_max"),
             bf_queue_len=stats.get("bf_queue_len"),
+            schedule_exit_end_job_queue=schedule_exit.get("end_job_queue"),
+            schedule_exit_default_queue_depth=schedule_exit.get(
+                "default_queue_depth"
+            ),
+            schedule_exit_max_job_start=schedule_exit.get("max_job_start"),
+            schedule_exit_max_rpc_cnt=schedule_exit.get("max_rpc_cnt"),
+            schedule_exit_max_sched_time=schedule_exit.get("max_sched_time"),
+            schedule_exit_licenses=schedule_exit.get("licenses"),
+            bf_exit_end_job_queue=bf_exit.get("end_job_queue"),
+            bf_exit_max_job_start=bf_exit.get("bf_max_job_start"),
+            bf_exit_max_job_test=bf_exit.get("bf_max_job_test"),
+            bf_exit_max_time=bf_exit.get("bf_max_time"),
+            bf_exit_node_space_size=bf_exit.get("bf_node_space_size"),
+            bf_exit_state_changed=bf_exit.get("state_changed"),
         )
         return result
 

--- a/gcm/schemas/slurm/sdiag.py
+++ b/gcm/schemas/slurm/sdiag.py
@@ -35,3 +35,19 @@ class Sdiag:
     bf_cycle_sum: Optional[int] = None
     bf_cycle_max: Optional[int] = None
     bf_queue_len: Optional[int] = None
+
+    # Schedule exit statistics
+    schedule_exit_end_job_queue: Optional[int] = None
+    schedule_exit_default_queue_depth: Optional[int] = None
+    schedule_exit_max_job_start: Optional[int] = None
+    schedule_exit_max_rpc_cnt: Optional[int] = None
+    schedule_exit_max_sched_time: Optional[int] = None
+    schedule_exit_licenses: Optional[int] = None
+
+    # Backfill exit statistics
+    bf_exit_end_job_queue: Optional[int] = None
+    bf_exit_max_job_start: Optional[int] = None
+    bf_exit_max_job_test: Optional[int] = None
+    bf_exit_max_time: Optional[int] = None
+    bf_exit_node_space_size: Optional[int] = None
+    bf_exit_state_changed: Optional[int] = None

--- a/gcm/tests/test_slurm.py
+++ b/gcm/tests/test_slurm.py
@@ -513,6 +513,18 @@ class TestSlurmCliClient:
             bf_cycle_sum=371434634,
             bf_cycle_max=47125449,
             bf_queue_len=411,
+            schedule_exit_end_job_queue=54,
+            schedule_exit_default_queue_depth=0,
+            schedule_exit_max_job_start=0,
+            schedule_exit_max_rpc_cnt=0,
+            schedule_exit_max_sched_time=281,
+            schedule_exit_licenses=0,
+            bf_exit_end_job_queue=10,
+            bf_exit_max_job_start=0,
+            bf_exit_max_job_test=0,
+            bf_exit_max_time=0,
+            bf_exit_node_space_size=0,
+            bf_exit_state_changed=0,
         )
 
         assert result == expected
@@ -572,6 +584,18 @@ class TestSlurmCliClient:
             bf_cycle_sum=None,
             bf_cycle_max=None,
             bf_queue_len=None,
+            schedule_exit_end_job_queue=None,
+            schedule_exit_default_queue_depth=None,
+            schedule_exit_max_job_start=None,
+            schedule_exit_max_rpc_cnt=None,
+            schedule_exit_max_sched_time=None,
+            schedule_exit_licenses=None,
+            bf_exit_end_job_queue=None,
+            bf_exit_max_job_start=None,
+            bf_exit_max_job_test=None,
+            bf_exit_max_time=None,
+            bf_exit_node_space_size=None,
+            bf_exit_state_changed=None,
         )
 
         assert result == expected


### PR DESCRIPTION
## Summary:
Extend the slurm monitor sdiag telemetry with the schedule_exit and bf_exit sub-section counters surfaced by sdiag --json. These counters expose why the main scheduler and the backfill scheduler stopped each cycle (e.g., end of job queue, max time, max job start, max RPC count), which gives much better visibility into scheduler tuning and saturation than the existing aggregate cycle stats alone.

## Test Plan

- Updated and ran the existing sdiag JSON parsing tests against the checked-in sample-sdiag-output.json, including the missing-fields case. Ran 'pytest gcm/tests/test_slurm.py gcm/tests/test_slurm_rest_client.py'
- all 25 tests passed.

```
(gcm-test-py310) yongl@yongl-login-0:/storage/home/yongl/repos/gcm$ gcm slurm_monitor --sink=stdout --once
[{"derived_cluster": "fair-aws-rc-1", "server_thread_count": 1, "agent_queue_size": 0, "agent_count": 0, "agent_thread_count": 0, "dbd_agent_queue_size": 0, "schedule_cycle_max": 69, "schedule_cycle_mean": 69, "schedule_cycle_sum": 69, "schedule_cycle_total": 1, "schedule_cycle_per_minute": 1, "schedule_queue_length": 0, "sdiag_jobs_submitted": 0, "sdiag_jobs_started": 0, "sdiag_jobs_completed": 0, "sdiag_jobs_canceled": 0, "sdiag_jobs_failed": 0, "sdiag_jobs_pending": 0, "sdiag_jobs_running": 0, "bf_backfilled_jobs": 0, "bf_cycle_mean": 0, "bf_cycle_sum": 0, "bf_cycle_max": 0, "bf_queue_len": 0, "schedule_exit_end_job_queue": 1, "schedule_exit_default_queue_depth": 0, "schedule_exit_max_job_start": 0, "schedule_exit_max_rpc_cnt": 0, "schedule_exit_max_sched_time": 0, "schedule_exit_licenses": 0, "bf_exit_end_job_queue": 0, "bf_exit_max_job_start": 0, "bf_exit_max_job_test": 0, "bf_exit_max_time": 0, "bf_exit_node_space_size": 0, "bf_exit_state_changed": 0, "nodes_allocated": 0, "nodes_completing": 0, "nodes_down": 0, "nodes_drained": 1, "nodes_draining": 0, "nodes_fail": 0, "nodes_failing": 0, "nodes_future": 0, "nodes_idle": 34, "nodes_inval": 0, "nodes_maint": 0, "nodes_reboot_issued": 0, "nodes_reboot_requested": 0, "nodes_mixed": 0, "nodes_perfctrs": 0, "nodes_planned": 0, "nodes_power_down": 0, "nodes_powered_down": 0, "nodes_powering_down": 0, "nodes_powering_up": 0, "nodes_reserved": 0, "nodes_unknown": 0, "nodes_not_responding": 0, "nodes_unknown_state": 0, "nodes_total": 35, "total_cpus_avail": 6400, "total_gpus_avail": 264, "total_cpus_up": 6208, "total_gpus_up": 256, "total_cpus_down": 192, "total_gpus_down": 8, "cluster": "fair-aws-rc-1", "running_and_pending_users": 0, "jobs_pending": 0, "gpus_pending": 0, "nodes_pending": 0, "jobs_failed": 0, "jobs_running": 0, "jobs_without_user": 0, "total_cpus_alloc": 0, "total_down_nodes": 1, "total_gpus_alloc": 0, "total_nodes_alloc": 0}]
(gcm-test-py310) yongl@yongl-login-0:/storage/home/yongl/repos/gcm$ python -m pytest gcm/tests/test_slurm.py -v
============================================================================ test session starts ============================================================================
platform linux -- Python 3.10.0, pytest-8.4.0, pluggy-1.6.0 -- /home/yongl/miniconda3/envs/gcm-test-py310/bin/python
cachedir: .pytest_cache
rootdir: /storage/home/yongl/repos/gcm
configfile: pyproject.toml
plugins: mock-3.14.1, xdist-3.7.0, typeguard-2.13.3, subprocess-1.5.3, requests-mock-1.12.1
collected 6 items                                                                                                                                                           

gcm/tests/test_slurm.py::TestSlurmCliClient::test_squeue[expected0] PASSED                                                                                            [ 16%]
gcm/tests/test_slurm.py::TestSlurmCliClient::test_squeue_throws_if_popen_throws PASSED                                                                                [ 33%]
gcm/tests/test_slurm.py::TestSlurmCliClient::test_sinfo_throws_if_popen_throws PASSED                                                                                 [ 50%]
gcm/tests/test_slurm.py::TestSlurmCliClient::test_sinfo_structured[sinfo-output-for-structured.txt-expected0] PASSED                                                  [ 66%]
gcm/tests/test_slurm.py::TestSlurmCliClient::test_parse_sdiag_json PASSED                                                                                             [ 83%]
gcm/tests/test_slurm.py::TestSlurmCliClient::test_parse_sdiag_json_with_missing_fields PASSED                                                                         [100%]


============================================================================= 6 passed in 0.16s =============================================================================
You can verify E2E test results in the following urls:
```