### PR TITLE
Make RSC PyOxidizer builds offline (#154)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,13 @@ PYOX_DEBUG_OUT=build/x86_64-unknown-linux-gnu/debug
 PYOX_RELEASE_OUT=build/x86_64-unknown-linux-gnu/release
 GCM_SRCS:=$(shell find gcm/ -type f -name '*py')
 VERSION:=$(shell cat gcm/version.txt)
+PYOXIDIZER_EXTRA_ARGS:=
+ifneq ($(PYOXIDIZER_SYSTEM_RUST),)
+PYOXIDIZER_EXTRA_ARGS += --system-rust
+endif
+ifneq ($(PYOXIDIZER_PYTHON_DISTRIBUTION),)
+PYOXIDIZER_EXTRA_ARGS += --var PYTHON_DISTRIBUTION $(PYOXIDIZER_PYTHON_DISTRIBUTION)
+endif
 
 .PHONY: all
 all: gcm, health_checks
@@ -17,7 +24,7 @@ clean: clean_pyox
 gcm: $(PYOX_DEBUG_OUT)/install/gcm
 
 $(PYOX_RELEASE_OUT)/install/gcm: pyoxidizer.bzl requirements.txt $(GCM_SRCS)
-	pyoxidizer build --release --var VERSION $(VERSION) gcm resources_gcm install_gcm
+	pyoxidizer build --release --var VERSION $(VERSION) $(PYOXIDIZER_EXTRA_ARGS) gcm resources_gcm install_gcm
 
 .PHONY: release/gcm
 release/gcm: $(PYOX_RELEASE_OUT)/install/gcm
@@ -26,7 +33,7 @@ release/gcm: $(PYOX_RELEASE_OUT)/install/gcm
 health_checks: $(PYOX_DEBUG_OUT)/install/health_checks
 
 $(PYOX_RELEASE_OUT)/install/health_checks: pyoxidizer.bzl requirements.txt $(GCM_SRCS)
-	pyoxidizer build --release --var VERSION $(VERSION) health_checks resources_hc install_hc
+	pyoxidizer build --release --var VERSION $(VERSION) $(PYOXIDIZER_EXTRA_ARGS) health_checks resources_hc install_hc
 
 .PHONY: release/health_checks
 release/health_checks: $(PYOX_RELEASE_OUT)/install/health_checks

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -1,9 +1,22 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 PYTHON_VERSION = "3.10"
+# Keep in sync with download_pyoxidizer_wheels.sh.
+PYTHON_DISTRIBUTION_SHA256 = "ddf27f962f0a13a4ff94d9dd51b55a33e82b97320fddfe42ce4ca74a6af1e70a"
+
+def make_python_distribution():
+    python_distribution = VARS.get("PYTHON_DISTRIBUTION")
+    if python_distribution:
+        return PythonDistribution(
+            sha256 = PYTHON_DISTRIBUTION_SHA256,
+            local_path = python_distribution,
+            flavor = "standalone",
+        )
+
+    return default_python_distribution(python_version = PYTHON_VERSION)
 
 def make_gcm():
-    dist = default_python_distribution(python_version = PYTHON_VERSION)
+    dist = make_python_distribution()
     version = VARS.get("VERSION")
     export_vars = "import os; os.environ['GCM_VERSION'] = '" + version + "';"
 
@@ -11,6 +24,8 @@ def make_gcm():
     policy.resources_location_fallback = "filesystem-relative:gcm_lib"
 
     python_config = dist.make_python_interpreter_config()
+    # Avoid PyOxidizer's jemalloc Cargo feature so the offline vendor set stays minimal.
+    python_config.allocator_backend = "default"
     python_config.run_command = export_vars + "from gcm.monitoring.cli.gcm import main; main()"
 
     # Set initial value for `sys.path`. If the string `$ORIGIN` exists in
@@ -22,19 +37,13 @@ def make_gcm():
         config = python_config,
     )
 
-    # NOTE: `--no-binary pydantic` because pyoxidizer has trouble with Cython modules
-    # https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_packaging_extension_modules.html#known-incompatibility-with-cython
-    # and Pydantic uses Cython https://github.com/pydantic/pydantic/blob/585ec35bd74ff81f0e482c6d484670bca11f7829/docs/install.md#performance-vs-package-size-trade-off
-    # We don't care *that* much about performance so avoiding compiled modules is the easiest workaround.
-    # TODO (T139437042): It seems like Pydantic v2 won't be using Cython anymore so when it's released we should revisit whether
-    # this flag is still necessary
-    exe.add_python_resources(exe.pip_install(["--no-binary", "pydantic", "-r", "requirements.txt"]))
+    exe.add_python_resources(exe.pip_install(["-r", "requirements.txt"]))
     exe.add_python_resources(exe.pip_install(["--no-deps", CWD]))
 
     return exe
 
 def make_health_checks():
-    dist = default_python_distribution(python_version = PYTHON_VERSION)
+    dist = make_python_distribution()
     version = VARS.get("VERSION")
     export_vars = "import os; os.environ['GCM_VERSION'] = '" + version + "';"
 
@@ -45,6 +54,8 @@ def make_health_checks():
     policy.resources_location_fallback = "filesystem-relative:hc_lib"
 
     python_config = dist.make_python_interpreter_config()
+    # Avoid PyOxidizer's jemalloc Cargo feature so the offline vendor set stays minimal.
+    python_config.allocator_backend = "default"
     python_config.run_command = export_vars + "from gcm.health_checks.cli.health_checks import health_checks; health_checks()"
 
     # Set initial value for `sys.path`. If the string `$ORIGIN` exists in
@@ -56,13 +67,7 @@ def make_health_checks():
         config = python_config,
     )
 
-    # NOTE: `--no-binary pydantic` because pyoxidizer has trouble with Cython modules
-    # https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_packaging_extension_modules.html#known-incompatibility-with-cython
-    # and Pydantic uses Cython https://github.com/pydantic/pydantic/blob/585ec35bd74ff81f0e482c6d484670bca11f7829/docs/install.md#performance-vs-package-size-trade-off
-    # We don't care *that* much about performance so avoiding compiled modules is the easiest workaround.
-    # TODO (T139437042): It seems like Pydantic v2 won't be using Cython anymore so when it's released we should revisit whether
-    # this flag is still necessary
-    exe.add_python_resources(exe.pip_install(["--no-binary", "pydantic", "-r", "requirements.txt"]))
+    exe.add_python_resources(exe.pip_install(["-r", "requirements.txt"]))
     exe.add_python_resources(exe.pip_install(["--no-deps", CWD]))
 
     return exe


### PR DESCRIPTION
Summary:

Stop cloud/meta_hpc_gcm Conveyor from depending on live egress inside the RSC systemd-nspawn container. The first failure was pip through fwdproxy, but PyOxidizer also fetched its CPython distribution, Rust toolchain/crates, and Cargo-generated metadata through paths that are not reliable in Sandcastle.

## What's New
| Component | Description |
|-----------|-------------|
| ai_infra/rsc/build:download_pyoxidizer_wheels | Builds a host-side PyOxidizer wheelhouse with PyOxidizer 0.24.0, the pinned CPython 3.10 python-build-standalone archive, and vendored Cargo crates extracted from PyOxidizer's pinned lockfile. |
| fair_infra/gcm:gcm_pyoxidizer_wheelhouse | Extends the staged wheelhouse with GCM/healthchecks Python requirements before entering the RSC container. |
| build_gcm_common.sh | Installs PyOxidizer from /var/out/python_wheels, forces pip offline, verifies the staged CPython and Cargo vendor artifacts exist, points PyOxidizer at the staged CPython archive, uses system Rust, and forces Cargo offline against the staged vendor dir. |
| build_gpu_burn_internal.sh | Applies the same offline PyOxidizer, CPython, system Rust, Cargo vendor, and partial-stage checks to gpu_burn wrapper binaries. |
| fair_infra/gcm/Makefile | Plumbs optional PyOxidizer args for system Rust and local CPython distribution without changing the default dev path. |
| fair_infra/gcm/pyoxidizer.bzl | Uses a local PythonDistribution when provided and keeps the old default_python_distribution fallback. |
| ai_infra/rsc/compute:gpu_burn_build | Applies the same offline PyOxidizer, CPython, and Cargo path to gpu_burn wrapper binaries. |

## Key Design Decisions
- Stage network dependencies on the host before entering RSC: this removes the Sandcastle-only broken in-container fwdproxy path.
- Keep fallback behavior for non-Buck/manual callers: if /var/out/python_wheels is absent, the scripts still use the previous fwdproxy path.
- Use system Rust plus vendored crates: PyOxidizer's managed Rust bootstrap downloads from static.rust-lang.org, then Cargo downloads from crates.io. Both are now avoided.
- Wrap only `cargo init`: Cargo 1.95 defaults new projects to edition 2024, but PyOxidizer 0.24's cargo_toml parser only supports up to 2021. The wrapper adds `--edition 2021` only for init and delegates every other Cargo command to /usr/bin/cargo.
- Keep Cargo state under /tmp: root-owned Cargo cache files under Buck OUT_DIR broke cleanup after failed container runs.
- Use `network_access` instead of `uses_sudo` for wheelhouse genrules: these genrules only prefetch artifacts and do not need sudo.

Reviewed By: calebho, jimou-meta, xman1979

Differential Revision: D108664638


