### PR TITLE
fix dual cluster args to SLURMLog()

### DIFF
--- a/gcm/monitoring/cli/slurm_monitor.py
+++ b/gcm/monitoring/cli/slurm_monitor.py
@@ -206,37 +206,41 @@ def get_slurm_log(
             if avg_time_job_suspended:
                 job_suspended_mean, job_suspended_variance = avg_time_job_suspended
 
-    slurm_log = SLURMLog(
-        cluster=cluster,
-        derived_cluster=derived_cluster,
-        active_users=active_users,
-        running_and_pending_users=running_and_pending_users,
-        runaway_jobs=runaway_jobs,
-        avg_cpus_alloc_per_job=avg_cpus_alloc_per_job,
-        avg_gpus_alloc_per_job=avg_gpus_alloc_per_job,
-        jobs_per_user_mean=jobs_per_user_mean,
-        jobs_per_user_variance=jobs_per_user_variance,
-        job_runtime_mean=job_runtime_mean,
-        job_runtime_variance=job_runtime_variance,
-        job_suspended_mean=job_suspended_mean,
-        job_suspended_variance=job_suspended_variance,
-        job_wait_time_mean=job_wait_time_mean,
-        job_wait_time_variance=job_wait_time_variance,
-        jobs_pending=jobs_pending,
-        gpus_pending=gpus_pending,
-        nodes_pending=node_pending,
-        jobs_failed=jobs_failed,
-        jobs_running=jobs_running,
-        jobs_without_user=jobs_without_user,
-        jobs_dist_training_percent=jobs_dist_training_percent,
-        total_cpus_alloc=total_cpus_alloc,
-        total_gpus_alloc=total_gpus_alloc,
-        total_nodes_alloc=total_nodes_alloc,
-        total_down_nodes=total_down_nodes,
+    slurm_log_kwargs = {
+        "derived_cluster": derived_cluster,
+        "active_users": active_users,
+        "running_and_pending_users": running_and_pending_users,
+        "runaway_jobs": runaway_jobs,
+        "avg_cpus_alloc_per_job": avg_cpus_alloc_per_job,
+        "avg_gpus_alloc_per_job": avg_gpus_alloc_per_job,
+        "jobs_per_user_mean": jobs_per_user_mean,
+        "jobs_per_user_variance": jobs_per_user_variance,
+        "job_runtime_mean": job_runtime_mean,
+        "job_runtime_variance": job_runtime_variance,
+        "job_suspended_mean": job_suspended_mean,
+        "job_suspended_variance": job_suspended_variance,
+        "job_wait_time_mean": job_wait_time_mean,
+        "job_wait_time_variance": job_wait_time_variance,
+        "jobs_pending": jobs_pending,
+        "gpus_pending": gpus_pending,
+        "nodes_pending": node_pending,
+        "jobs_failed": jobs_failed,
+        "jobs_running": jobs_running,
+        "jobs_without_user": jobs_without_user,
+        "jobs_dist_training_percent": jobs_dist_training_percent,
+        "total_cpus_alloc": total_cpus_alloc,
+        "total_gpus_alloc": total_gpus_alloc,
+        "total_nodes_alloc": total_nodes_alloc,
+        "total_down_nodes": total_down_nodes,
         **asdict(total_cpus_gpus),
         **asdict(node_states),
         **asdict(sdiag),
-    )
+        # Sdiag carries a `cluster` field (added in D95971502) that is only
+        # populated on the standalone sdiag log path.
+        # add cluster last to keep the canonical value
+        "cluster": cluster,
+    }
+    slurm_log = SLURMLog(**slurm_log_kwargs)
     yield slurm_log
 
 

--- a/gcm/tests/test_slurm_monitor.py
+++ b/gcm/tests/test_slurm_monitor.py
@@ -12,7 +12,12 @@ from zoneinfo import ZoneInfo
 import pytest
 from click.testing import CliRunner
 
-from gcm.monitoring.cli.slurm_monitor import CliObjectImpl, collect_sdiag, main
+from gcm.monitoring.cli.slurm_monitor import (
+    CliObjectImpl,
+    collect_sdiag,
+    get_slurm_log,
+    main,
+)
 from gcm.monitoring.clock import AwareDatetime, PT
 from gcm.monitoring.slurm.sinfo import (
     compute_allocated_resources,
@@ -35,7 +40,7 @@ from gcm.schemas.slurm.sinfo import Sinfo
 from gcm.schemas.slurm.sinfo_cpus_gpus import SinfoCpusGpus
 from gcm.schemas.slurm.sinfo_node import SinfoNode
 from gcm.schemas.slurm.sinfo_node_states import SinfoNodeStates
-from gcm.schemas.slurm.slurm_log import SLURMLogAccountMetrics
+from gcm.schemas.slurm.slurm_log import SLURMLog, SLURMLogAccountMetrics
 from typeguard import typechecked
 
 PT_TIMEZONE = PT
@@ -5460,6 +5465,47 @@ def _make_sdiag() -> Sdiag:
         schedule_cycle_last=42,
         bf_active=False,
     )
+
+
+class TestGetSlurmLog:
+    """get_slurm_log builds a SLURMLog by unpacking **asdict(sdiag) alongside an
+    explicit cluster= kwarg. Since Sdiag carries a `cluster` field (added in
+    D95971502), the unpack must drop it so it does not collide with the explicit
+    kwarg. Regression for: SLURMLog() got multiple values for keyword argument
+    'cluster'."""
+
+    def test_builds_slurm_log_without_cluster_kwarg_collision(self) -> None:
+        from unittest.mock import patch
+
+        start = AwareDatetime(dt.datetime(2026, 1, 1, tzinfo=UTC_TIMEZONE))
+        end = AwareDatetime(dt.datetime(2026, 1, 1, 0, 5, tzinfo=UTC_TIMEZONE))
+
+        # No jobs => skip the job-stat branch and go straight to the SLURMLog
+        # construction that previously raised on the duplicate cluster kwarg.
+        with patch(
+            "gcm.monitoring.cli.slurm_monitor.parse_slurm_jobs", return_value=[]
+        ):
+            out = list(
+                get_slurm_log(
+                    sinfo=Sinfo(nodes=[]),
+                    sdiag=_make_sdiag(),
+                    start_time=start,
+                    end_time=end,
+                    cluster="shared-aws-use2-1",
+                    derived_cluster="shared-aws-use2-1",
+                    logger=logging.getLogger("test"),
+                )
+            )
+
+        slurm_logs = [row for row in out if isinstance(row, SLURMLog)]
+        self_log = slurm_logs[0]
+        assert len(slurm_logs) == 1
+        # The explicit cluster kwarg wins; Sdiag.cluster (None here) is dropped.
+        assert self_log.cluster == "shared-aws-use2-1"
+        assert self_log.derived_cluster == "shared-aws-use2-1"
+        # Other Sdiag fields still propagate through the **asdict(sdiag) unpack.
+        assert self_log.schedule_cycle_last == 42
+        assert self_log.server_thread_count == 1
 
 
 class TestCollectSdiag:


### PR DESCRIPTION
Summary:
s678528 - in fair_infra/gcm/gcm/monitoring/cli/slurm_monitor.py - D95971502 introduced a duplicate cluster kwarg to SLURMLog() which is causing crash looping of the slurm monitoring container in gcm.

exempt `cluster` from coming

Reviewed By: Yash0270

Differential Revision: D109335413


