### PR TITLE
check_ethlink: add nmcli fallback for CentOS 10 + unit tests

### DIFF
--- a/gcm/health_checks/checks/check_ethlink.py
+++ b/gcm/health_checks/checks/check_ethlink.py
@@ -2,6 +2,7 @@
 # All rights reserved.
 import json
 import os
+import subprocess
 from dataclasses import dataclass
 from typing import Any, Collection, Dict, List, Optional, Protocol
 
@@ -238,8 +239,68 @@ class EthLinkCheckImpl:
                 return {
                     field[0]: field[1] for field in map(lambda x: x.split("="), lines)
                 }
-        else:
+        return self._get_intf_ifcfg_from_nmcli(ifname)
+
+    @staticmethod
+    def _get_intf_ifcfg_from_nmcli(ifname: str) -> Optional[Dict[str, str]]:
+        """
+        CentOS 10+ fallback: synthesize an ifcfg-equivalent dict from nmcli when
+        /etc/sysconfig/network-scripts/ifcfg-* is unavailable (ifcfg-rh plugin
+        is dropped on CentOS 10).
+        """
+        device_fields = [
+            "GENERAL.HWADDR",
+            "GENERAL.DEVICE",
+            "GENERAL.TYPE",
+            "GENERAL.MTU",
+            "GENERAL.STATE",
+            "GENERAL.CONNECTION",
+        ]
+        try:
+            device_out = subprocess.check_output(
+                [
+                    "nmcli",
+                    "-t",
+                    "-e",
+                    "no",
+                    "-f",
+                    ",".join(device_fields),
+                    "device",
+                    "show",
+                    ifname,
+                ],
+                stderr=subprocess.DEVNULL,
+                timeout=30,
+            ).decode()
+        except (
+            subprocess.CalledProcessError,
+            FileNotFoundError,
+            subprocess.TimeoutExpired,
+        ):
             return None
+
+        device_props: Dict[str, str] = {}
+        for line in device_out.splitlines():
+            key, sep, value = line.partition(":")
+            if sep:
+                device_props[key.strip()] = value.strip()
+
+        if not device_props.get("GENERAL.HWADDR"):
+            return None
+
+        nmcli_type = device_props.get("GENERAL.TYPE", "")
+        # nmcli prints "--" for an unmanaged/inactive connection; treat it as empty.
+        connection = device_props.get("GENERAL.CONNECTION", "")
+        if connection == "--":
+            connection = ""
+        return {
+            "HWADDR": device_props["GENERAL.HWADDR"],
+            "DEVICE": device_props.get("GENERAL.DEVICE", ifname),
+            "NAME": connection or ifname,
+            "TYPE": nmcli_type.capitalize() if nmcli_type else "",
+            "MTU": device_props.get("GENERAL.MTU", ""),
+            "STATE": device_props.get("GENERAL.STATE", ""),
+        }
 
     def query_link_speed(self, ifname: str) -> Optional[str]:
         """

--- a/gcm/tests/health_checks_tests/test_check_ethlink.py
+++ b/gcm/tests/health_checks_tests/test_check_ethlink.py
@@ -2,15 +2,17 @@
 # All rights reserved.
 import json
 import logging
+import subprocess
 from dataclasses import dataclass, field
 from importlib import resources
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
 
-from gcm.health_checks.checks.check_ethlink import check_ethlink
+from gcm.health_checks.checks.check_ethlink import check_ethlink, EthLinkCheckImpl
 from gcm.health_checks.types import ExitCode
 from gcm.tests.data import health_checks
 
@@ -132,3 +134,97 @@ def test_check_ethlink(
 
     assert result.exit_code == expected[0].value
     assert expected[1] in caplog.text
+
+
+NMCLI_CHECK_OUTPUT_PATH = (
+    "gcm.health_checks.checks.check_ethlink.subprocess.check_output"
+)
+
+SAMPLE_NMCLI_DEVICE_OUTPUT = (
+    "GENERAL.HWADDR:10:70:FD:88:B7:D0\n"
+    "GENERAL.DEVICE:enp161s0\n"
+    "GENERAL.TYPE:ethernet\n"
+    "GENERAL.MTU:9192\n"
+    "GENERAL.STATE:100 (connected)\n"
+    "GENERAL.CONNECTION:enp161s0\n"
+)
+
+
+def test_nmcli_fallback_happy_path() -> None:
+    with patch(
+        NMCLI_CHECK_OUTPUT_PATH, return_value=SAMPLE_NMCLI_DEVICE_OUTPUT.encode()
+    ):
+        result = EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0")
+    assert result == {
+        "HWADDR": "10:70:FD:88:B7:D0",
+        "DEVICE": "enp161s0",
+        "NAME": "enp161s0",
+        "TYPE": "Ethernet",
+        "MTU": "9192",
+        "STATE": "100 (connected)",
+    }
+
+
+def test_nmcli_fallback_invokes_subprocess_with_timeout() -> None:
+    with patch(
+        NMCLI_CHECK_OUTPUT_PATH,
+        return_value=SAMPLE_NMCLI_DEVICE_OUTPUT.encode(),
+    ) as mock_check_output:
+        EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0")
+    mock_check_output.assert_called_once()
+    args, kwargs = mock_check_output.call_args
+    assert args[0][0] == "nmcli"
+    assert args[0][-3:] == ["device", "show", "enp161s0"]
+    assert kwargs["timeout"] == 30
+    assert kwargs["stderr"] == subprocess.DEVNULL
+
+
+def test_nmcli_fallback_missing_hwaddr_returns_none() -> None:
+    output = "GENERAL.HWADDR:\nGENERAL.DEVICE:enp161s0\nGENERAL.TYPE:ethernet\n"
+    with patch(NMCLI_CHECK_OUTPUT_PATH, return_value=output.encode()):
+        assert EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0") is None
+
+
+def test_nmcli_fallback_command_not_found_returns_none() -> None:
+    with patch(NMCLI_CHECK_OUTPUT_PATH, side_effect=FileNotFoundError()):
+        assert EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0") is None
+
+
+def test_nmcli_fallback_command_fails_returns_none() -> None:
+    with patch(
+        NMCLI_CHECK_OUTPUT_PATH,
+        side_effect=subprocess.CalledProcessError(returncode=1, cmd="nmcli"),
+    ):
+        assert EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0") is None
+
+
+def test_nmcli_fallback_command_times_out_returns_none() -> None:
+    with patch(
+        NMCLI_CHECK_OUTPUT_PATH,
+        side_effect=subprocess.TimeoutExpired(cmd="nmcli", timeout=30),
+    ):
+        assert EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0") is None
+
+
+@pytest.mark.parametrize("connection_value", ["--", ""])
+def test_nmcli_fallback_unmanaged_connection_falls_back_to_ifname(
+    connection_value: str,
+) -> None:
+    output = (
+        "GENERAL.HWADDR:AA:BB:CC:DD:EE:FF\n"
+        "GENERAL.DEVICE:eth0\n"
+        "GENERAL.TYPE:ethernet\n"
+        "GENERAL.MTU:1500\n"
+        "GENERAL.STATE:30 (disconnected)\n"
+        f"GENERAL.CONNECTION:{connection_value}\n"
+    )
+    with patch(NMCLI_CHECK_OUTPUT_PATH, return_value=output.encode()):
+        result = EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("eth0")
+    assert result == {
+        "HWADDR": "AA:BB:CC:DD:EE:FF",
+        "DEVICE": "eth0",
+        "NAME": "eth0",
+        "TYPE": "Ethernet",
+        "MTU": "1500",
+        "STATE": "30 (disconnected)",
+    }


### PR DESCRIPTION
## Summary

On CentOS 10 / EL10, ifcfg network config files under /etc/sysconfig/network-scripts/ no longer exist — NetworkManager dropped the ifcfg plugin. This breaks check_ethlink's get_intf_ifcfg() which relies on parsing those files to retrieve interface properties (HWADDR, DEVICE, NAME, TYPE, MTU).

This PR adds a fallback path: when the ifcfg file is missing, we query NetworkManager via `nmcli -t device show <ifname>` to retrieve the same properties. The fallback handles:
- Missing nmcli binary (returns None gracefully)
- Command failures and timeouts (30s timeout)
- Unmanaged interfaces where GENERAL.CONNECTION is "--" or empty (falls back to interface name)

## Test Plan

7 new unit tests added covering:
- Happy path: full property dict returned from nmcli output
- Subprocess invocation: correct argv and timeout=30 / stderr=DEVNULL
- Missing HWADDR: returns None
- FileNotFoundError (nmcli not installed): returns None
- CalledProcessError (nmcli fails): returns None
- TimeoutExpired: returns None
- Unmanaged connection ("--" and ""): falls back to interface name

Run tests with: nox -s tests -- gcm/tests/health_checks_tests/test_check_ethlink.py Black formatting verified clean.