### PR TITLE
check_ethlink: surface missing netlink interface as CRITICAL, skip virtual devices

### DIFF
--- a/gcm/health_checks/checks/check_ethlink.py
+++ b/gcm/health_checks/checks/check_ethlink.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 import json
 import os
-import subprocess
 from dataclasses import dataclass
+from subprocess import CalledProcessError, check_output, DEVNULL, TimeoutExpired
 from typing import Any, Collection, Dict, List, Optional, Protocol
 
 import click
@@ -138,10 +138,21 @@ def check_link_state(
     """
     eth_manifest = EthManifest(devices=node_manifest["eth"])
     for device, intf_spec in eth_manifest.devices.items():
-        # We can assume this is nonempty because _check_cfg_macaddr checks that we don't have missing netlink interfaces
-        intf_state = list(
-            filter(lambda x: x["ifname"] == intf_spec.netdev, netlink_info)
-        )[0]
+        if intf_spec.phys is None or not intf_spec.phys:
+            continue
+        intf_state = next(
+            (x for x in netlink_info if x["ifname"] == intf_spec.netdev),
+            None,
+        )
+        if intf_state is None:
+            check.check_status = ExitCode.CRITICAL
+            check.short_out = (
+                f"Missing netlink interface {device} ({intf_spec.netdev})!"
+            )
+            check.long_out.append(
+                f"{device} ({intf_spec.netdev}) is in the manifest but absent from `ip -j addr`"
+            )
+            continue
 
         if intf_state["operstate"] != "UP":
             check.check_status = ExitCode.CRITICAL
@@ -257,7 +268,7 @@ class EthLinkCheckImpl:
             "GENERAL.CONNECTION",
         ]
         try:
-            device_out = subprocess.check_output(
+            device_out = check_output(
                 [
                     "nmcli",
                     "-t",
@@ -269,13 +280,13 @@ class EthLinkCheckImpl:
                     "show",
                     ifname,
                 ],
-                stderr=subprocess.DEVNULL,
+                stderr=DEVNULL,
                 timeout=30,
             ).decode()
         except (
-            subprocess.CalledProcessError,
+            CalledProcessError,
             FileNotFoundError,
-            subprocess.TimeoutExpired,
+            TimeoutExpired,
         ):
             return None
 

--- a/gcm/tests/health_checks_tests/test_check_ethlink.py
+++ b/gcm/tests/health_checks_tests/test_check_ethlink.py
@@ -4,17 +4,23 @@ import json
 import logging
 import subprocess
 from dataclasses import dataclass, field
-from importlib import resources
+from importlib import import_module, resources
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
-
 from gcm.health_checks.checks.check_ethlink import check_ethlink, EthLinkCheckImpl
 from gcm.health_checks.types import ExitCode
 from gcm.tests.data import health_checks
+
+# Resolve the module via sys.modules (import_module) rather than `import … as`,
+# because `gcm.health_checks.checks.__init__` rebinds the `check_ethlink`
+# attribute on the package to the Click Command of the same name. `import … as`
+# does a getattr-style lookup at the end and would yield the Command, not the
+# module.
+_ethlink_mod = import_module("gcm.health_checks.checks.check_ethlink")
 
 
 @dataclass
@@ -136,10 +142,6 @@ def test_check_ethlink(
     assert expected[1] in caplog.text
 
 
-NMCLI_CHECK_OUTPUT_PATH = (
-    "gcm.health_checks.checks.check_ethlink.subprocess.check_output"
-)
-
 SAMPLE_NMCLI_DEVICE_OUTPUT = (
     "GENERAL.HWADDR:10:70:FD:88:B7:D0\n"
     "GENERAL.DEVICE:enp161s0\n"
@@ -151,8 +153,8 @@ SAMPLE_NMCLI_DEVICE_OUTPUT = (
 
 
 def test_nmcli_fallback_happy_path() -> None:
-    with patch(
-        NMCLI_CHECK_OUTPUT_PATH, return_value=SAMPLE_NMCLI_DEVICE_OUTPUT.encode()
+    with patch.object(
+        _ethlink_mod, "check_output", return_value=SAMPLE_NMCLI_DEVICE_OUTPUT.encode()
     ):
         result = EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0")
     assert result == {
@@ -166,8 +168,9 @@ def test_nmcli_fallback_happy_path() -> None:
 
 
 def test_nmcli_fallback_invokes_subprocess_with_timeout() -> None:
-    with patch(
-        NMCLI_CHECK_OUTPUT_PATH,
+    with patch.object(
+        _ethlink_mod,
+        "check_output",
         return_value=SAMPLE_NMCLI_DEVICE_OUTPUT.encode(),
     ) as mock_check_output:
         EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0")
@@ -181,26 +184,28 @@ def test_nmcli_fallback_invokes_subprocess_with_timeout() -> None:
 
 def test_nmcli_fallback_missing_hwaddr_returns_none() -> None:
     output = "GENERAL.HWADDR:\nGENERAL.DEVICE:enp161s0\nGENERAL.TYPE:ethernet\n"
-    with patch(NMCLI_CHECK_OUTPUT_PATH, return_value=output.encode()):
+    with patch.object(_ethlink_mod, "check_output", return_value=output.encode()):
         assert EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0") is None
 
 
 def test_nmcli_fallback_command_not_found_returns_none() -> None:
-    with patch(NMCLI_CHECK_OUTPUT_PATH, side_effect=FileNotFoundError()):
+    with patch.object(_ethlink_mod, "check_output", side_effect=FileNotFoundError()):
         assert EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0") is None
 
 
 def test_nmcli_fallback_command_fails_returns_none() -> None:
-    with patch(
-        NMCLI_CHECK_OUTPUT_PATH,
+    with patch.object(
+        _ethlink_mod,
+        "check_output",
         side_effect=subprocess.CalledProcessError(returncode=1, cmd="nmcli"),
     ):
         assert EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0") is None
 
 
 def test_nmcli_fallback_command_times_out_returns_none() -> None:
-    with patch(
-        NMCLI_CHECK_OUTPUT_PATH,
+    with patch.object(
+        _ethlink_mod,
+        "check_output",
         side_effect=subprocess.TimeoutExpired(cmd="nmcli", timeout=30),
     ):
         assert EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0") is None
@@ -218,7 +223,7 @@ def test_nmcli_fallback_unmanaged_connection_falls_back_to_ifname(
         "GENERAL.STATE:30 (disconnected)\n"
         f"GENERAL.CONNECTION:{connection_value}\n"
     )
-    with patch(NMCLI_CHECK_OUTPUT_PATH, return_value=output.encode()):
+    with patch.object(_ethlink_mod, "check_output", return_value=output.encode()):
         result = EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("eth0")
     assert result == {
         "HWADDR": "AA:BB:CC:DD:EE:FF",


### PR DESCRIPTION
## Summary

On CentOS 10 hosts running the build with the new nmcli fallback from

    WARNING - check ethlink. Exception occured: list index out of range

The previous "ifcfg-* missing" failure mode is fixed, but the check now crashes with an opaque IndexError instead of saying what's wrong.

Root cause:
Before #160, an interface whose ifcfg file was absent caused check_cfg_macaddr to short-circuit with CRITICAL "Missing interface", so check_link_state never ran for that device. After #160, the nmcli fallback synthesizes a config for NetworkManager-managed interfaces whose kernel netdev name differs from (or is currently absent in) the manifest, so check_cfg_macaddr passes and check_link_state runs.

check_link_state then does:

    intf_state = list(
        filter(lambda x: x["ifname"] == intf_spec.netdev, netlink_info)
    )[0]

with a stale comment claiming check_cfg_macaddr already guarantees nonempty. It does not — check_cfg_macaddr only validates ifcfg config + ethtool MAC, never `ip -j addr`. When the manifested netdev is absent from netlink_info, the [0] raises IndexError and the whole check fails as a bare WARNING + exception string, hiding the real problem.

A secondary contributor is that check_link_state iterates every manifest device (physical, bond legs, virtual), but only physical interfaces are expected to appear in `ip -j addr` under that exact name. check_cfg_macaddr filters by `intf_spec.phys` for the same reason; check_link_state was missing that filter.

What this change does:
- Skip non-physical interfaces in check_link_state (mirror the existing check_cfg_macaddr filter at lines 69-70).
- Replace `list(filter(...))[0]` with `next((x for x in netlink_info if x["ifname"] == netdev), None)` and emit a clean CRITICAL "Missing netlink interface" with a long-form explanation when the interface really is absent. `continue` so remaining manifested devices are still reported in one pass.
- Drop the stale comment about check_cfg_macaddr filtering interfaces.

## Test Plan

- Existing tests in gcm/tests/health_checks_tests/test_check_ethlink.py cover the happy / nic-swap / down-speed cases with manifested netdevs present in intf_status — those paths are unchanged.
- Will rebuild fb-healthchecks rpm and test on sbx once merged
