### PR TITLE
Add `scontrol_topology` GCM monitor for periodic Slurm topology collection (#167)

### DIFF
--- a/gcm/monitoring/cli/gcm.py
+++ b/gcm/monitoring/cli/gcm.py
@@ -19,6 +19,7 @@ from gcm.monitoring.cli import (
     sacctmgr_user,
     scontrol,
     scontrol_config,
+    scontrol_topology,
     slurm_job_monitor,
     slurm_monitor,
     sprio,
@@ -48,6 +49,7 @@ main.add_command(slurm_monitor.main, name="slurm_monitor")
 main.add_command(sacct_backfill.main, name="sacct_backfill")
 main.add_command(scontrol.main, name="scontrol")
 main.add_command(scontrol_config.main, name="scontrol_config")
+main.add_command(scontrol_topology.main, name="scontrol_topology")
 main.add_command(sprio.main, name="sprio")
 main.add_command(sshare.main, name="sshare")
 main.add_command(storage.main, name="storage")

--- a/gcm/monitoring/cli/scontrol_topology.py
+++ b/gcm/monitoring/cli/scontrol_topology.py
@@ -1,0 +1,205 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import (
+    Collection,
+    Generator,
+    Hashable,
+    Literal,
+    Mapping,
+    Optional,
+    Protocol,
+    runtime_checkable,
+    TYPE_CHECKING,
+)
+
+import click
+import clusterscope
+from gcm.exporters import registry
+from gcm.monitoring.click import (
+    chunk_size_option,
+    click_default_cmd,
+    cluster_option,
+    dry_run_option,
+    heterogeneous_cluster_v1_option,
+    interval_option,
+    log_folder_option,
+    log_level_option,
+    once_option,
+    retries_option,
+    sink_option,
+    sink_opts_option,
+    stdout_option,
+)
+from gcm.monitoring.clock import Clock, ClockImpl
+from gcm.monitoring.dataclass_utils import instantiate_dataclass
+from gcm.monitoring.sink.protocol import DataType, SinkAdditionalParams, SinkImpl
+from gcm.monitoring.sink.utils import Factory, HasRegistry
+from gcm.monitoring.slurm.client import SlurmCliClient, SlurmClient
+from gcm.monitoring.slurm.derived_cluster import get_derived_cluster
+from gcm.monitoring.slurm.nodelist_parsers import nodelist
+from gcm.monitoring.utils.monitor import run_data_collection_loop
+from gcm.schemas.slurm.scontrol_topology import ScontrolTopology
+
+from typeguard import typechecked
+
+if TYPE_CHECKING:
+    from _typeshed import DataclassInstance
+
+LOGGER_NAME = "scontrol_topology"
+logger: logging.Logger
+
+_MAX_NODELIST_ENTRIES = 10000
+
+
+@runtime_checkable
+class CliObject(HasRegistry[SinkImpl], Protocol):
+    @property
+    def clock(self) -> Clock: ...
+
+    def cluster(self) -> str: ...
+
+    @property
+    def slurm_client(self) -> SlurmClient: ...
+
+
+@dataclass
+class CliObjectImpl:
+    clock: Clock = field(default_factory=ClockImpl)
+    slurm_client: SlurmClient = field(default_factory=SlurmCliClient)
+    registry: Mapping[str, Factory[SinkImpl]] = field(default_factory=lambda: registry)
+
+    def cluster(self) -> str:
+        return clusterscope.cluster()
+
+
+_default_obj: CliObject = CliObjectImpl()
+
+
+def _expand_nodes(
+    raw_nodes: str, logger: logging.Logger
+) -> tuple[list[str] | None, int]:
+    if not raw_nodes:
+        return None, 0
+    parsed, _ = nodelist()(raw_nodes)
+    if parsed is None:
+        logger.warning(f"Failed to parse nodelist: {raw_nodes[:200]}")
+        return None, 0
+    node_count = len(parsed)
+    if node_count > _MAX_NODELIST_ENTRIES:
+        logger.warning(
+            f"Truncating topology nodelist from {node_count} to {_MAX_NODELIST_ENTRIES} entries"
+        )
+        return parsed[:_MAX_NODELIST_ENTRIES] + ["..."], node_count
+    return parsed, node_count
+
+
+def collect_scontrol_topology(
+    slurm_client: SlurmClient,
+    cluster: str,
+    heterogeneous_cluster_v1: bool,
+    logger: logging.Logger,
+) -> Generator[DataclassInstance, None, None]:
+    attributes: dict[Hashable, str | int] = {
+        "cluster": cluster,
+    }
+
+    for line in slurm_client.scontrol_topology():
+        if not line.strip():
+            continue
+
+        message: dict[Hashable, str | int] = {**attributes}
+        for item in line.strip().split(" "):
+            if "=" not in item:
+                continue
+            k, v = item.split("=", 1)
+            message[k] = v
+
+        raw_nodes = str(message.get("Nodes", ""))
+        expanded, node_count = _expand_nodes(raw_nodes, logger)
+
+        message["derived_cluster"] = get_derived_cluster(
+            data=message,
+            heterogeneous_cluster_v1=heterogeneous_cluster_v1,
+            cluster=cluster,
+        )
+
+        topo = instantiate_dataclass(ScontrolTopology, message, logger=logger)
+        topo.Nodes = expanded
+        topo.node_count = node_count
+
+        yield topo
+
+
+@click_default_cmd(context_settings={"obj": _default_obj})
+@cluster_option
+@sink_option
+@sink_opts_option
+@log_level_option
+@log_folder_option
+@stdout_option
+@heterogeneous_cluster_v1_option
+@interval_option(default=60)
+@once_option
+@retries_option
+@dry_run_option
+@chunk_size_option
+@click.pass_obj
+@typechecked
+def main(
+    obj: CliObject,
+    cluster: Optional[str],
+    sink: str,
+    sink_opts: Collection[str],
+    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+    log_folder: str,
+    stdout: bool,
+    heterogeneous_cluster_v1: bool,
+    interval: int,
+    once: bool,
+    retries: int,
+    dry_run: bool,
+    chunk_size: int,
+) -> None:
+    """
+    Collects slurm topology information and sends to sink.
+    """
+
+    def collect_scontrol_topology_callable(
+        cluster: str, _interval: int, logger: logging.Logger
+    ) -> Generator[DataclassInstance, None, None]:
+        return collect_scontrol_topology(
+            slurm_client=obj.slurm_client,
+            cluster=cluster,
+            heterogeneous_cluster_v1=heterogeneous_cluster_v1,
+            logger=logger,
+        )
+
+    run_data_collection_loop(
+        logger_name=LOGGER_NAME,
+        log_folder=log_folder,
+        stdout=stdout,
+        log_level=log_level,
+        cluster=obj.cluster() if cluster is None else cluster,
+        clock=obj.clock,
+        once=once,
+        interval=interval,
+        data_collection_tasks=[
+            (
+                collect_scontrol_topology_callable,
+                SinkAdditionalParams(
+                    data_type=DataType.LOG,
+                    heterogeneous_cluster_v1=heterogeneous_cluster_v1,
+                ),
+            ),
+        ],
+        sink=sink,
+        sink_opts=sink_opts,
+        retries=retries,
+        chunk_size=chunk_size,
+        dry_run=dry_run,
+        registry=obj.registry,
+    )

--- a/gcm/monitoring/slurm/client.py
+++ b/gcm/monitoring/slurm/client.py
@@ -125,6 +125,9 @@ class SlurmClient(Protocol):
     def scontrol_config(self) -> Iterable[str]:
         """Get lines of scontrol config information."""
 
+    def scontrol_topology(self) -> Iterable[str]:
+        """Get lines of scontrol topology information."""
+
     def count_runaway_jobs(self) -> int:
         """Return the count of runaway jobs"""
 
@@ -503,6 +506,9 @@ class SlurmCliClient(SlurmClient):
 
     def scontrol_config(self) -> Iterable[str]:
         return _gen_lines(self.__popen(["scontrol", "show", "config"]))
+
+    def scontrol_topology(self) -> Iterable[str]:
+        return _gen_lines(self.__popen(["scontrol", "show", "topo"]))
 
     def count_runaway_jobs(self) -> int:
         p = subprocess.Popen(

--- a/gcm/monitoring/slurm/rest_client.py
+++ b/gcm/monitoring/slurm/rest_client.py
@@ -247,6 +247,12 @@ class SlurmRestClient(SlurmClient):
             "not slurmctld config. Use SlurmCliClient"
         )
 
+    def scontrol_topology(self) -> NoReturn:
+        raise NotImplementedError(
+            "scontrol_topology is not available via Slurm REST API; "
+            "use SlurmCliClient"
+        )
+
     def count_runaway_jobs(self) -> NoReturn:
         raise NotImplementedError(
             "count_runaway_jobs is not available via Slurm REST API; "

--- a/gcm/schemas/slurm/scontrol_topology.py
+++ b/gcm/schemas/slurm/scontrol_topology.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+from dataclasses import dataclass
+
+from gcm.monitoring.coerce import maybe_int
+from gcm.schemas.dataclass import parsed_field
+from gcm.schemas.slurm.derived_cluster import DerivedCluster
+
+
+@dataclass(kw_only=True)
+class ScontrolTopology(DerivedCluster):
+    """Schema for scontrol show topo output.
+
+    Supports both block topology (BlockName/BlockIndex/BlockSize) and
+    switch topology (SwitchName/Level/LinkSpeed/Switches) formats.
+    """
+
+    cluster: str
+
+    BlockName: str | None = parsed_field(parser=str)
+    BlockIndex: int | None = parsed_field(parser=maybe_int)
+    BlockSize: int | None = parsed_field(parser=maybe_int)
+
+    SwitchName: str | None = parsed_field(parser=str)
+    Level: int | None = parsed_field(parser=maybe_int)
+    LinkSpeed: int | None = parsed_field(parser=maybe_int)
+    Switches: str | None = parsed_field(parser=str)
+
+    Nodes: list[str] | None = None
+    node_count: int | None = None

--- a/gcm/tests/data/sample-scontrol-show-topo-block-output.txt
+++ b/gcm/tests/data/sample-scontrol-show-topo-block-output.txt
@@ -1,0 +1,3 @@
+BlockName=block_DH1-062-US-EAST-04B BlockIndex=0 Nodes=g3-129-[057,059,063] BlockSize=18
+BlockName=block_DH1-064-US-EAST-04B BlockIndex=1 Nodes=g3-129-[127,129,131] BlockSize=18
+BlockName=block_DH1-067-US-EAST-04B BlockIndex=3 Nodes=g3-129-[235,237],g3-130-[001,003] BlockSize=18

--- a/gcm/tests/data/sample-scontrol-show-topo-switch-output.txt
+++ b/gcm/tests/data/sample-scontrol-show-topo-switch-output.txt
@@ -1,0 +1,4 @@
+SwitchName=cpu Level=0 LinkSpeed=1 Nodes=cpu-000-109,cpu-002-219,cpu-003-040
+SwitchName=h100 Level=0 LinkSpeed=1 Nodes=h100-008-154,h100-236-009
+SwitchName=spine-use2-az3-0 Level=1 LinkSpeed=1 Nodes=h100-008-154,h100-236-009 Switches=h100
+SwitchName=data-transfer Level=0 LinkSpeed=1 Nodes=

--- a/gcm/tests/test_scontrol_topology.py
+++ b/gcm/tests/test_scontrol_topology.py
@@ -1,0 +1,130 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+import json
+from dataclasses import dataclass, field
+from importlib import resources
+from pathlib import Path
+from typing import Iterable, Mapping, Protocol
+
+from click.testing import CliRunner
+from gcm.exporters.stdout import Stdout
+
+from gcm.monitoring.cli.scontrol_topology import main
+from gcm.monitoring.clock import Clock
+from gcm.monitoring.sink.protocol import SinkImpl
+from gcm.monitoring.sink.utils import Factory
+from gcm.tests import data
+from gcm.tests.fakes import FakeClock
+
+TEST_CLUSTER = "fake_cluster"
+
+
+class ScontrolTopologyClient(Protocol):
+    def scontrol_topology(self) -> Iterable[str]: ...
+
+
+class FakeSlurmClientBlock:
+    def scontrol_topology(self) -> Iterable[str]:
+        with resources.open_text(
+            data, "sample-scontrol-show-topo-block-output.txt"
+        ) as f:
+            for line in f:
+                yield line.rstrip("\n")
+
+
+class FakeSlurmClientSwitch:
+    def scontrol_topology(self) -> Iterable[str]:
+        with resources.open_text(
+            data, "sample-scontrol-show-topo-switch-output.txt"
+        ) as f:
+            for line in f:
+                yield line.rstrip("\n")
+
+
+@dataclass
+class FakeCliObject:
+    clock: Clock = field(default_factory=FakeClock)
+    slurm_client: ScontrolTopologyClient = field(default_factory=FakeSlurmClientBlock)
+    registry: Mapping[str, Factory[SinkImpl]] = field(
+        default_factory=lambda: {"stdout": Stdout}
+    )
+
+    def cluster(self) -> str:
+        return TEST_CLUSTER
+
+    def format_epilog(self) -> str:
+        return ""
+
+
+def test_cli_block_topology(tmp_path: Path) -> None:
+    runner = CliRunner(mix_stderr=False)
+    fake_obj = FakeCliObject(slurm_client=FakeSlurmClientBlock())
+    result = runner.invoke(
+        main,
+        [
+            "--sink=stdout",
+            f"--log-folder={tmp_path}",
+            "--once",
+        ],
+        obj=fake_obj,
+        catch_exceptions=True,
+    )
+
+    assert result.exit_code == 0, result.stderr
+    lines = [line for line in result.stdout.strip().split("\n") if line.strip()]
+    parsed = json.loads(lines[0])
+
+    assert parsed[0]["cluster"] == TEST_CLUSTER
+    assert parsed[0]["BlockName"] == "block_DH1-062-US-EAST-04B"
+    assert parsed[0]["BlockIndex"] == 0
+    assert parsed[0]["BlockSize"] == 18
+    assert parsed[0]["Nodes"] == ["g3-129-057", "g3-129-059", "g3-129-063"]
+    assert parsed[0]["node_count"] == 3
+    assert "SwitchName" not in parsed[0]
+
+    assert parsed[2]["BlockName"] == "block_DH1-067-US-EAST-04B"
+    assert parsed[2]["BlockIndex"] == 3
+    assert parsed[2]["Nodes"] == [
+        "g3-129-235",
+        "g3-129-237",
+        "g3-130-001",
+        "g3-130-003",
+    ]
+    assert parsed[2]["node_count"] == 4
+
+
+def test_cli_switch_topology(tmp_path: Path) -> None:
+    runner = CliRunner(mix_stderr=False)
+    fake_obj = FakeCliObject(slurm_client=FakeSlurmClientSwitch())
+    result = runner.invoke(
+        main,
+        [
+            "--sink=stdout",
+            f"--log-folder={tmp_path}",
+            "--once",
+        ],
+        obj=fake_obj,
+        catch_exceptions=True,
+    )
+
+    assert result.exit_code == 0, result.stderr
+    lines = [line for line in result.stdout.strip().split("\n") if line.strip()]
+    parsed = json.loads(lines[0])
+
+    assert parsed[0]["SwitchName"] == "cpu"
+    assert parsed[0]["Level"] == 0
+    assert parsed[0]["LinkSpeed"] == 1
+    assert parsed[0]["Nodes"] == ["cpu-000-109", "cpu-002-219", "cpu-003-040"]
+    assert parsed[0]["node_count"] == 3
+    assert "BlockName" not in parsed[0]
+
+    assert parsed[1]["SwitchName"] == "h100"
+    assert parsed[1]["Nodes"] == ["h100-008-154", "h100-236-009"]
+    assert parsed[1]["node_count"] == 2
+
+    assert parsed[2]["SwitchName"] == "spine-use2-az3-0"
+    assert parsed[2]["Level"] == 1
+    assert parsed[2]["Switches"] == "h100"
+
+    assert parsed[3]["SwitchName"] == "data-transfer"
+    assert parsed[3]["node_count"] == 0

--- a/gcm/tests/test_slurm_rest_client.py
+++ b/gcm/tests/test_slurm_rest_client.py
@@ -216,6 +216,13 @@ class TestSlurmRestClient:
         with pytest.raises(NotImplementedError, match="scontrol_config"):
             client.scontrol_config()
 
+    def test_scontrol_topology_not_implemented(self) -> None:
+        session = create_autospec(requests.Session, instance=True)
+        client = self._make_client(session)
+
+        with pytest.raises(NotImplementedError, match="scontrol_topology"):
+            client.scontrol_topology()
+
     def test_auth_token_header(self) -> None:
         session = create_autospec(requests.Session, instance=True)
         session.headers = {}


### PR DESCRIPTION
Summary:

Adds a new GCM monitor that runs `scontrol show topo` every 60 seconds and publishes the results as logs for the `fair_slurm_topology` Scuba table. This supports two use cases from T275974051: SLA compliance monitoring for partial racks and topology-aware job debugging for GB300.

The monitor handles both block topology format (`BlockName`/`BlockIndex`/`BlockSize`, used on CW clusters) and switch/tree topology format (`SwitchName`/`Level`/`LinkSpeed`/`Switches`). Node lists in Slurm hostlist notation (e.g., `g3-129-[057,059,063]`) are expanded into individual node names using the existing `nodelist()` parser, with a 10000-entry truncation safety limit.

Reviewed By: Yash0270, xman1979

Differential Revision: D110108419


