### PR TITLE
Coerce bool ODS metrics to int; soft-skip missing scribe_category

### DIFF
--- a/gcm/monitoring/cli/slurm_monitor.py
+++ b/gcm/monitoring/cli/slurm_monitor.py
@@ -366,6 +366,13 @@ def collect_sdiag(
     yield replace(sdiag, cluster=cluster)
 
 
+def _sdiag_log_routable(sink: str, sink_opts: Collection[str]) -> bool:
+    """Whether the sink can route the sdiag LOG stream (graph_api needs a category)."""
+    return sink != "graph_api" or any(
+        opt.split("=", 1)[0].strip() == "sdiag_scribe_category" for opt in sink_opts
+    )
+
+
 @click_default_cmd(
     context_settings={
         "obj": _default_obj,
@@ -418,6 +425,8 @@ def main(
     ) -> Generator[Sdiag, None, None]:
         return collect_sdiag(obj=obj, cluster=cluster, logger=logger)
 
+    sdiag_log_routable = _sdiag_log_routable(sink, sink_opts)
+
     run_data_collection_loop(
         logger_name=LOGGER_NAME,
         log_folder=log_folder,
@@ -436,15 +445,21 @@ def main(
                     heterogeneous_cluster_v1=heterogeneous_cluster_v1,
                 ),
             ),
-            # Task B: Sdiag -> LOG -> scribe (perfpipe_fair_sdiag_v2) ->
-            # Scuba (perfpipe_fair_sdiag_v2) via graph_api._write_log. Reads cached
-            # sdiag from Task A.
-            (
-                collect_sdiag_callable,
-                SinkAdditionalParams(
-                    data_type=DataType.LOG,
-                    data_identifier=DataIdentifier.SDIAG,
-                ),
+            # Task B: Sdiag -> LOG -> scribe (perfpipe_fair_sdiag_v2) -> Scuba
+            # via graph_api._write_log. Reads cached sdiag from Task A. Registered
+            # only when the sink can route it.
+            *(
+                [
+                    (
+                        collect_sdiag_callable,
+                        SinkAdditionalParams(
+                            data_type=DataType.LOG,
+                            data_identifier=DataIdentifier.SDIAG,
+                        ),
+                    )
+                ]
+                if sdiag_log_routable
+                else []
             ),
         ],
         sink=sink,

--- a/gcm/monitoring/meta_utils/ods.py
+++ b/gcm/monitoring/meta_utils/ods.py
@@ -156,6 +156,12 @@ def get_payload(config: ODSConfig, data: List[ODSData]) -> ODSPayload:
     }
 
 
+def _as_ods_number(value: Union[int, float]) -> Union[int, float]:
+    # bool is a subclass of int; coerce to 0/1 so ODS gets a JSON number, not
+    # true/false, which it rejects with a 400 that drops the whole batch.
+    return int(value) if isinstance(value, bool) else value
+
+
 def get_ods_data(
     entity: str,
     data: DataclassInstance,
@@ -168,12 +174,12 @@ def get_ods_data(
         entity=entity,
         time=unixtime,
         metrics={
-            metrics_prefix + metric: value
+            metrics_prefix + metric: _as_ods_number(value)
             for metric, value in asdict(data, dict_factory=flatten_dict_factory).items()
             if isinstance(value, (int, float))
         }
         | {
-            new_metrics_prefix + metric: value
+            new_metrics_prefix + metric: _as_ods_number(value)
             for metric, value in asdict(data, dict_factory=flatten_dict_factory).items()
             if isinstance(value, (int, float))
         },

--- a/gcm/tests/test_ods.py
+++ b/gcm/tests/test_ods.py
@@ -2,6 +2,7 @@
 # All rights reserved.
 import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List
 
@@ -9,7 +10,13 @@ import pytest
 import requests
 
 from gcm.monitoring.clock import ClockImpl
-from gcm.monitoring.meta_utils.ods import get_payload, ODSConfig, ODSData, write
+from gcm.monitoring.meta_utils.ods import (
+    get_ods_data,
+    get_payload,
+    ODSConfig,
+    ODSData,
+    write,
+)
 from pytest_mock import MockerFixture
 from requests_mock import Mocker as RequestsMocker
 
@@ -188,6 +195,41 @@ def test_write_with_non_finite_values_sends_valid_json(
     assert requests_mock.last_request is not None
     sent = json.loads(requests_mock.last_request.json()["datapoints"])
     assert {dp["key"] for dp in sent} == {"good"}
+
+
+@dataclass
+class _SampleMetrics:
+    count: int = 5
+    bf_active: bool = True
+    rpcs_by_user_json: str = "[]"
+
+
+class TestGetODSData:
+    @staticmethod
+    def test_coerces_bool_to_int() -> None:
+        # bf_active is a bool. ODS metric values must be numbers: a JSON
+        # true/false is rejected with HTTP 400, which drops the whole batch.
+        # So coerce it to 0/1.
+        active = get_ods_data(
+            entity="e", data=_SampleMetrics(bf_active=True), unixtime=TEST_TIME
+        ).metrics
+        assert active["gcm.bf_active"] == 1
+        assert type(active["gcm.bf_active"]) is int
+
+        inactive = get_ods_data(
+            entity="e", data=_SampleMetrics(bf_active=False), unixtime=TEST_TIME
+        ).metrics
+        assert inactive["gcm.bf_active"] == 0
+
+    @staticmethod
+    def test_drops_non_numeric() -> None:
+        # Non-numeric fields (e.g. the rpcs_by_user_json string) are not ODS
+        # metrics and must be dropped, never sent to ODS.
+        metrics = get_ods_data(
+            entity="e", data=_SampleMetrics(), unixtime=TEST_TIME
+        ).metrics
+        assert metrics["gcm.count"] == 5
+        assert "gcm.rpcs_by_user_json" not in metrics
 
 
 class TestODSConfig:

--- a/gcm/tests/test_slurm_monitor.py
+++ b/gcm/tests/test_slurm_monitor.py
@@ -13,6 +13,7 @@ import pytest
 from click.testing import CliRunner
 
 from gcm.monitoring.cli.slurm_monitor import (
+    _sdiag_log_routable,
     CliObjectImpl,
     collect_sdiag,
     get_slurm_log,
@@ -5586,3 +5587,22 @@ class TestCollectSdiag:
             )
             == []
         )
+
+
+class TestSdiagLogRoutable:
+    """graph_api needs sdiag_scribe_category to route the sdiag LOG stream."""
+
+    @staticmethod
+    def test_graph_api_without_category_not_routable() -> None:
+        assert not _sdiag_log_routable("graph_api", ["ods_entity=cluster"])
+
+    @staticmethod
+    def test_graph_api_with_category_routable() -> None:
+        assert _sdiag_log_routable(
+            "graph_api",
+            ["ods_entity=cluster", "sdiag_scribe_category=perfpipe_fair_sdiag_v2"],
+        )
+
+    @staticmethod
+    def test_non_graph_api_sink_routable() -> None:
+        assert _sdiag_log_routable("otel", [])


### PR DESCRIPTION
`bf_active` (a `bool`) is spread into the SLURMLog ODS metric via #141. Since `bool` is a subclass of `int` it passes the numeric filter in `get_ods_data` and serializes as JSON `true`/`false`; ODS rejects it with `400 (#100) Param datapoints[i][value] must be a number`, and the all-or-nothing batch POST drops **every** metric. (#165's NaN/Inf guard can't catch a bool.)

The same change adds an sdiag LOG task; on clusters without `sdiag_scribe_category` it can't be routed and crash-loops the LOG path.

## Changes
- `ods.py`: coerce `bool` → `int` (0/1) so ODS gets a JSON number.
- `slurm_monitor.py`: register the sdiag LOG task only when the sink can route it (graph_api needs `sdiag_scribe_category`); sdiag still feeds the ODS metric path.

## Testing

**Unit / CI:** `ufmt` / `flake8` / `mypy` clean; new bool-coercion + gating tests pass.

**End-to-end on fair-aws-rc-1** — built a standalone `gcm_binary.par` from this branch and ran `slurm_monitor --once` inside the gcm pod against the live ODS endpoint + real token (no conveyor):

Real binary, before vs after:
```
# deployed OLD binary (/usr/bin/gcm) --once
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url:
  https://graph.facebook.com/v21.0/ods_metrics

# FIX binary (this branch) --once
exit=0    # clean run, no 400
```

ODS read-back confirms the datapoints actually landed (fresh, from the `--once` runs — the pod daemon still runs the old 400ing binary, so nothing else publishes):
```
fair-aws-rc-1  gcm.jobs_running  2026-06-30 20:39:22  0.0
fair-aws-rc-1  gcm.bf_active     2026-06-30 20:39:22  0.0
```
`gcm.bf_active` now lands as a number (`0` = `False` coerced to 0/1) — a key that never successfully published before, because the old binary 400'd every batch.
