### PR TITLE
sdiag LOG: gate routing in exporter, not the main loop

### DIFF
--- a/gcm/exporters/graph_api.py
+++ b/gcm/exporters/graph_api.py
@@ -69,6 +69,7 @@ class GraphAPI:
             DataIdentifier.SDIAG: sdiag_scribe_category,
         }
         self.scribe_write = scribe_write
+        self._log_skip_warned: set[Optional[DataIdentifier]] = set()
         if ods_entity is None:
             self._ods_entity = socket.gethostname()
         else:
@@ -158,7 +159,18 @@ class GraphAPI:
                 )
             category = self.data_identifier_to_scribe_map[data_identifier]
 
-        assert category is not None, "scribe_category argument is missing"
+        if category is None:
+            # No scribe_category configured for this stream (e.g. a cluster
+            # without sdiag_scribe_category).
+            stream = additional_params.data_identifier
+            if stream not in self._log_skip_warned:
+                self._log_skip_warned.add(stream)
+                logger.warning(
+                    "graph_api sink has no scribe_category for LOG stream %s; "
+                    "skipping its writes.",
+                    stream.name if stream else "default",
+                )
+            return
         # converting messages to ScubaMessage before sending them through GraphAPI:
         # https://www.internalfb.com/intern/wiki/Scuba/Quick_Start_Guide/Data_Types/
         scribe_messages = list(map(to_scuba_message, data.message))

--- a/gcm/monitoring/cli/slurm_monitor.py
+++ b/gcm/monitoring/cli/slurm_monitor.py
@@ -366,13 +366,6 @@ def collect_sdiag(
     yield replace(sdiag, cluster=cluster)
 
 
-def _sdiag_log_routable(sink: str, sink_opts: Collection[str]) -> bool:
-    """Whether the sink can route the sdiag LOG stream (graph_api needs a category)."""
-    return sink != "graph_api" or any(
-        opt.split("=", 1)[0].strip() == "sdiag_scribe_category" for opt in sink_opts
-    )
-
-
 @click_default_cmd(
     context_settings={
         "obj": _default_obj,
@@ -425,8 +418,6 @@ def main(
     ) -> Generator[Sdiag, None, None]:
         return collect_sdiag(obj=obj, cluster=cluster, logger=logger)
 
-    sdiag_log_routable = _sdiag_log_routable(sink, sink_opts)
-
     run_data_collection_loop(
         logger_name=LOGGER_NAME,
         log_folder=log_folder,
@@ -446,20 +437,15 @@ def main(
                 ),
             ),
             # Task B: Sdiag -> LOG -> scribe (perfpipe_fair_sdiag_v2) -> Scuba
-            # via graph_api._write_log. Reads cached sdiag from Task A. Registered
-            # only when the sink can route it.
-            *(
-                [
-                    (
-                        collect_sdiag_callable,
-                        SinkAdditionalParams(
-                            data_type=DataType.LOG,
-                            data_identifier=DataIdentifier.SDIAG,
-                        ),
-                    )
-                ]
-                if sdiag_log_routable
-                else []
+            # via graph_api._write_log. Reads cached sdiag from Task A. The sink
+            # skips the write if it can't route the stream (graph_api needs
+            # sdiag_scribe_category); the exporter owns that decision.
+            (
+                collect_sdiag_callable,
+                SinkAdditionalParams(
+                    data_type=DataType.LOG,
+                    data_identifier=DataIdentifier.SDIAG,
+                ),
             ),
         ],
         sink=sink,

--- a/gcm/tests/test_publish_to_scribe.py
+++ b/gcm/tests/test_publish_to_scribe.py
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+import logging
 from dataclasses import dataclass
 from typing import cast
 from unittest.mock import create_autospec, MagicMock
@@ -147,7 +148,12 @@ class TestGraphAPISdiagRouting:
         assert call_args.args[0] == "cat_sdiag"
 
     @staticmethod
-    def test_sdiag_without_category_raises_assertion() -> None:
+    def test_sdiag_without_category_skips_write(
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # No sdiag_scribe_category configured: the exporter must skip the LOG
+        # write (warn-and-return) rather than fail, and warn only once per
+        # stream, not on every cycle.
         scribe_write = MagicMock()
         api = GraphAPI(
             app_secret="x|y",
@@ -155,12 +161,19 @@ class TestGraphAPISdiagRouting:
             sdiag_scribe_category=None,
             scribe_write=scribe_write,
         )
-        with pytest.raises(AssertionError, match="scribe_category"):
-            api.write(
-                Log(ts=100, message=[_DummyMsg()]),
-                SinkAdditionalParams(
-                    data_type=DataType.LOG,
-                    data_identifier=DataIdentifier.SDIAG,
-                ),
-            )
+        params = SinkAdditionalParams(
+            data_type=DataType.LOG,
+            data_identifier=DataIdentifier.SDIAG,
+        )
+        with caplog.at_level(logging.WARNING, logger="gcm.exporters.graph_api"):
+            for _ in range(3):
+                api.write(Log(ts=100, message=[_DummyMsg()]), params)
+
         assert scribe_write.call_count == 0
+        skips = [
+            r
+            for r in caplog.records
+            if "no scribe_category" in r.getMessage() and r.levelno == logging.WARNING
+        ]
+        assert len(skips) == 1
+        assert "SDIAG" in skips[0].getMessage()

--- a/gcm/tests/test_slurm_monitor.py
+++ b/gcm/tests/test_slurm_monitor.py
@@ -13,7 +13,6 @@ import pytest
 from click.testing import CliRunner
 
 from gcm.monitoring.cli.slurm_monitor import (
-    _sdiag_log_routable,
     CliObjectImpl,
     collect_sdiag,
     get_slurm_log,
@@ -5589,20 +5588,31 @@ class TestCollectSdiag:
         )
 
 
-class TestSdiagLogRoutable:
-    """graph_api needs sdiag_scribe_category to route the sdiag LOG stream."""
+class TestSdiagLogTaskRegistration:
+    """The sdiag LOG task is registered unconditionally; the exporter (not the
+    main loop) decides whether it can route the stream. Regression guard for
+    removing the _sdiag_log_routable gate from main."""
 
     @staticmethod
-    def test_graph_api_without_category_not_routable() -> None:
-        assert not _sdiag_log_routable("graph_api", ["ods_entity=cluster"])
+    def test_sdiag_log_task_registered_even_without_scribe_category() -> None:
+        from unittest.mock import patch
 
-    @staticmethod
-    def test_graph_api_with_category_routable() -> None:
-        assert _sdiag_log_routable(
-            "graph_api",
-            ["ods_entity=cluster", "sdiag_scribe_category=perfpipe_fair_sdiag_v2"],
-        )
+        from gcm.monitoring.sink.protocol import DataIdentifier, DataType
 
-    @staticmethod
-    def test_non_graph_api_sink_routable() -> None:
-        assert _sdiag_log_routable("otel", [])
+        runner = CliRunner(mix_stderr=False)
+        # graph_api sink with no sdiag_scribe_category: previously the sdiag LOG
+        # task would have been skipped in main; now it is always registered.
+        with patch("gcm.monitoring.cli.slurm_monitor.run_data_collection_loop") as loop:
+            result = runner.invoke(
+                main,
+                ["--sink", "graph_api", "--once", "--cluster", "cluster_name"],
+            )
+
+        assert result.exit_code == 0, result.output
+        tasks = loop.call_args.kwargs["data_collection_tasks"]
+        identifiers = [params.data_identifier for _, params in tasks]
+        types = [params.data_type for _, params in tasks]
+        assert DataIdentifier.SDIAG in identifiers
+        # The SLURMLog METRIC task and the sdiag LOG task are both present.
+        assert DataType.METRIC in types
+        assert DataType.LOG in types


### PR DESCRIPTION
Follow-up to #168, addressing @luccabb's review: move the sdiag LOG routability decision out of the main loop and into the exporter.

The sdiag LOG routability check lived in `slurm_monitor.main` (`_sdiag_log_routable`), leaking exporter-specific knowledge (that `graph_api` needs `sdiag_scribe_category`) into the main collection loop. This moves that decision into the exporter, where it belongs.

## Changes
- **`gcm/exporters/graph_api.py`** — in `_write_log`, when no `scribe_category` is configured for the stream, log a warning and skip the LOG write instead of asserting. To avoid per-cycle log spam on an expected steady-state config (a cluster deliberately run without `sdiag_scribe_category`), the skip **warns once per stream** (tracked in `_log_skip_warned`) and names the stream. The ODS metric path is unaffected.
- **`gcm/monitoring/cli/slurm_monitor.py`** — always register the sdiag LOG task; drop the `_sdiag_log_routable` helper and the conditional registration. The exporter now owns the "can I route this?" decision.
- **Tests** — the exporter test now asserts the write is skipped and the warning fires exactly once per stream across repeated cycles; a new `slurm_monitor` test asserts the sdiag LOG task is registered unconditionally in `main` (via `graph_api` sink with no category). Removed the obsolete `TestSdiagLogRoutable`.

### Notes for reviewers
- The skip now covers **all** graph_api LOG streams (JOB/NODE/STATVFS/PURE/SDIAG), not just sdiag — a missing category is warn-and-skip rather than a hard failure. That's intentional per "log instead of assert"; visibility is preserved by the one-time, stream-named WARNING.
- `ods.py`'s bool→int coercion stays as the `_as_ods_number` helper + comment, per the resolved discussion on #168.

## Testing
`ufmt` / `flake8` / `mypy` clean on all changed files. `pytest gcm/tests/test_publish_to_scribe.py gcm/tests/test_slurm_monitor.py` → **125 passed, 1 failed**; the single failure is `test_cli`, which fails identically on the base commit (it needs a real SLURM controller and is `skipif(CI)`) — not related to this change.
