### PR TITLE
check_ethlink: use connection binding MAC on CentOS 10 to fix bond slave check

### DIFF
--- a/gcm/health_checks/checks/check_ethlink.py
+++ b/gcm/health_checks/checks/check_ethlink.py
@@ -304,14 +304,66 @@ class EthLinkCheckImpl:
         connection = device_props.get("GENERAL.CONNECTION", "")
         if connection == "--":
             connection = ""
+
+        # For bond slaves, GENERAL.HWADDR reports the CURRENT MAC (inherited
+        # from the bond master via cloned-mac-address), not the permanent NIC
+        # MAC. Prefer the connection profile's 802-3-ethernet.mac-address,
+        # which is the binding MAC NetworkManager uses to pin the profile to
+        # a specific NIC — matches ethtool -P for both bonded and unbonded
+        # interfaces, and preserves the semantics of the CentOS 9 ifcfg HWADDR=
+        # field. Fall back to GENERAL.HWADDR if the connection lookup fails or
+        # the profile has no binding MAC set.
+        binding_mac = EthLinkCheckImpl._get_nmcli_connection_binding_mac(connection)
+        hwaddr = binding_mac or device_props["GENERAL.HWADDR"]
+
         return {
-            "HWADDR": device_props["GENERAL.HWADDR"],
+            "HWADDR": hwaddr,
             "DEVICE": device_props.get("GENERAL.DEVICE", ifname),
             "NAME": connection or ifname,
             "TYPE": nmcli_type.capitalize() if nmcli_type else "",
             "MTU": device_props.get("GENERAL.MTU", ""),
             "STATE": device_props.get("GENERAL.STATE", ""),
         }
+
+    @staticmethod
+    def _get_nmcli_connection_binding_mac(connection: str) -> Optional[str]:
+        """
+        Return the 802-3-ethernet.mac-address (binding MAC) from an nmcli
+        connection profile, or None if the connection is empty/unavailable or
+        the profile has no binding MAC set.
+        """
+        if not connection:
+            return None
+        try:
+            conn_out = check_output(
+                [
+                    "nmcli",
+                    "-t",
+                    "-e",
+                    "no",
+                    "-f",
+                    "802-3-ethernet.mac-address",
+                    "connection",
+                    "show",
+                    connection,
+                ],
+                stderr=DEVNULL,
+                timeout=30,
+            ).decode()
+        except (
+            CalledProcessError,
+            FileNotFoundError,
+            TimeoutExpired,
+        ):
+            return None
+
+        for line in conn_out.splitlines():
+            key, sep, value = line.partition(":")
+            if sep and key.strip() == "802-3-ethernet.mac-address":
+                value = value.strip()
+                if value and value != "--":
+                    return value
+        return None
 
     def query_link_speed(self, ifname: str) -> Optional[str]:
         """

--- a/gcm/tests/health_checks_tests/test_check_ethlink.py
+++ b/gcm/tests/health_checks_tests/test_check_ethlink.py
@@ -152,9 +152,43 @@ SAMPLE_NMCLI_DEVICE_OUTPUT = (
 )
 
 
+def _nmcli_side_effect(
+    device_out: Optional[bytes] = None,
+    connection_out: Optional[bytes] = None,
+    device_side_effect: Optional[BaseException] = None,
+    connection_side_effect: Optional[BaseException] = None,
+) -> Any:
+    """
+    Build a check_output side_effect that routes based on whether the argv
+    contains `device show` (returns/raises device_*) or `connection show`
+    (returns/raises connection_*).
+    """
+
+    def _impl(argv: List[str], *args: Any, **kwargs: Any) -> bytes:
+        if "device" in argv and "show" in argv:
+            if device_side_effect is not None:
+                raise device_side_effect
+            assert device_out is not None
+            return device_out
+        if "connection" in argv and "show" in argv:
+            if connection_side_effect is not None:
+                raise connection_side_effect
+            assert connection_out is not None
+            return connection_out
+        raise AssertionError(f"unexpected nmcli invocation: {argv!r}")
+
+    return _impl
+
+
 def test_nmcli_fallback_happy_path() -> None:
+    connection_out = "802-3-ethernet.mac-address:10:70:FD:88:B7:D0\n".encode()
     with patch.object(
-        _ethlink_mod, "check_output", return_value=SAMPLE_NMCLI_DEVICE_OUTPUT.encode()
+        _ethlink_mod,
+        "check_output",
+        side_effect=_nmcli_side_effect(
+            device_out=SAMPLE_NMCLI_DEVICE_OUTPUT.encode(),
+            connection_out=connection_out,
+        ),
     ):
         result = EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0")
     assert result == {
@@ -168,18 +202,104 @@ def test_nmcli_fallback_happy_path() -> None:
 
 
 def test_nmcli_fallback_invokes_subprocess_with_timeout() -> None:
+    connection_out = "802-3-ethernet.mac-address:10:70:FD:88:B7:D0\n".encode()
     with patch.object(
         _ethlink_mod,
         "check_output",
-        return_value=SAMPLE_NMCLI_DEVICE_OUTPUT.encode(),
+        side_effect=_nmcli_side_effect(
+            device_out=SAMPLE_NMCLI_DEVICE_OUTPUT.encode(),
+            connection_out=connection_out,
+        ),
     ) as mock_check_output:
         EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0")
-    mock_check_output.assert_called_once()
-    args, kwargs = mock_check_output.call_args
-    assert args[0][0] == "nmcli"
-    assert args[0][-3:] == ["device", "show", "enp161s0"]
-    assert kwargs["timeout"] == 30
-    assert kwargs["stderr"] == subprocess.DEVNULL
+    calls = mock_check_output.call_args_list
+    assert len(calls) == 2
+    device_args, device_kwargs = calls[0]
+    assert device_args[0][0] == "nmcli"
+    assert device_args[0][-3:] == ["device", "show", "enp161s0"]
+    assert device_kwargs["timeout"] == 30
+    assert device_kwargs["stderr"] == subprocess.DEVNULL
+    conn_args, conn_kwargs = calls[1]
+    assert conn_args[0][0] == "nmcli"
+    assert conn_args[0][-3:] == ["connection", "show", "enp161s0"]
+    assert "802-3-ethernet.mac-address" in conn_args[0]
+    assert conn_kwargs["timeout"] == 30
+    assert conn_kwargs["stderr"] == subprocess.DEVNULL
+
+
+def test_nmcli_fallback_bond_slave_uses_connection_binding_mac() -> None:
+    """
+    On a bond slave, `nmcli device show` reports the bond-inherited MAC as
+    GENERAL.HWADDR, but the connection profile's 802-3-ethernet.mac-address
+    still holds the real permanent NIC MAC. The check must compare against
+    the binding MAC so bond slaves do not spuriously fail.
+    """
+    device_out = (
+        "GENERAL.HWADDR:FA:CE:B0:0C:19:83\n"  # bond master's cloned MAC
+        "GENERAL.DEVICE:enp97s0f0np0\n"
+        "GENERAL.TYPE:ethernet\n"
+        "GENERAL.MTU:9192\n"
+        "GENERAL.STATE:100 (connected)\n"
+        "GENERAL.CONNECTION:enp97s0f0np0\n"
+    ).encode()
+    connection_out = "802-3-ethernet.mac-address:10:70:FD:BD:7D:5C\n".encode()
+    with patch.object(
+        _ethlink_mod,
+        "check_output",
+        side_effect=_nmcli_side_effect(
+            device_out=device_out,
+            connection_out=connection_out,
+        ),
+    ):
+        result = EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp97s0f0np0")
+    assert result is not None
+    assert result["HWADDR"] == "10:70:FD:BD:7D:5C"
+
+
+def test_nmcli_fallback_connection_missing_binding_mac_falls_back_to_device() -> None:
+    connection_out = "802-3-ethernet.mac-address:\n".encode()
+    with patch.object(
+        _ethlink_mod,
+        "check_output",
+        side_effect=_nmcli_side_effect(
+            device_out=SAMPLE_NMCLI_DEVICE_OUTPUT.encode(),
+            connection_out=connection_out,
+        ),
+    ):
+        result = EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0")
+    assert result is not None
+    assert result["HWADDR"] == "10:70:FD:88:B7:D0"
+
+
+def test_nmcli_fallback_connection_show_fails_falls_back_to_device() -> None:
+    with patch.object(
+        _ethlink_mod,
+        "check_output",
+        side_effect=_nmcli_side_effect(
+            device_out=SAMPLE_NMCLI_DEVICE_OUTPUT.encode(),
+            connection_side_effect=subprocess.CalledProcessError(
+                returncode=10, cmd="nmcli"
+            ),
+        ),
+    ):
+        result = EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0")
+    assert result is not None
+    assert result["HWADDR"] == "10:70:FD:88:B7:D0"
+
+
+def test_nmcli_fallback_connection_returns_placeholder_falls_back() -> None:
+    connection_out = "802-3-ethernet.mac-address:--\n".encode()
+    with patch.object(
+        _ethlink_mod,
+        "check_output",
+        side_effect=_nmcli_side_effect(
+            device_out=SAMPLE_NMCLI_DEVICE_OUTPUT.encode(),
+            connection_out=connection_out,
+        ),
+    ):
+        result = EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("enp161s0")
+    assert result is not None
+    assert result["HWADDR"] == "10:70:FD:88:B7:D0"
 
 
 def test_nmcli_fallback_missing_hwaddr_returns_none() -> None:
@@ -223,7 +343,12 @@ def test_nmcli_fallback_unmanaged_connection_falls_back_to_ifname(
         "GENERAL.STATE:30 (disconnected)\n"
         f"GENERAL.CONNECTION:{connection_value}\n"
     )
-    with patch.object(_ethlink_mod, "check_output", return_value=output.encode()):
+    # With no active connection name, we cannot look up a connection profile,
+    # so HWADDR must fall back to GENERAL.HWADDR — check_output should be
+    # called exactly once (device show only, no connection show).
+    with patch.object(
+        _ethlink_mod, "check_output", return_value=output.encode()
+    ) as mock_check_output:
         result = EthLinkCheckImpl._get_intf_ifcfg_from_nmcli("eth0")
     assert result == {
         "HWADDR": "AA:BB:CC:DD:EE:FF",
@@ -233,3 +358,4 @@ def test_nmcli_fallback_unmanaged_connection_falls_back_to_ifname(
         "MTU": "1500",
         "STATE": "30 (disconnected)",
     }
+    assert mock_check_output.call_count == 1


### PR DESCRIPTION
## Summary

The CentOS 10 nmcli fallback added in #159 read GENERAL.HWADDR from `nmcli device show`, which returns the interface's CURRENT MAC. For a bond slave, that MAC is inherited from the bond master via cloned-mac-address, so it does not match ethtool -P's permanent MAC and the check fires spuriously:

  PCIE_5 (enp97s0f0np0): expect fa:ce:b0:0c:19:83, actual 10:70:fd:bd:7d:5c

Both values are correct for what they measure; the comparison just isn't meaningful for a bond slave.

Fix: read the connection profile's 802-3-ethernet.mac-address (the binding MAC NetworkManager uses to pin the profile to a specific NIC) via `nmcli connection show <conn>`. This value matches ethtool -P for both bonded and unbonded interfaces on CentOS 10, and preserves the semantics of the CentOS 9 ifcfg HWADDR= field. If the connection lookup fails or the profile has no binding MAC set, fall back to GENERAL.HWADDR so existing hosts keep working.

## Test Plan

Unit tests:

  $ pytest gcm/tests/health_checks_tests/test_check_ethlink.py -v
  ======================== 19 passed in 0.NNs ========================

On real hardware (sbxlearn1983 - an RTX training host with two bonded 100G NICs where the bug reproduced):

Before the fix, `check-ethlink` reported CRITICAL because the bond slaves inherit the bond master's MAC in `ip link show`, which the old code was comparing against `ethtool -P` (the permanent MAC):

  $ sudo /bin/health_checks --config=... check-ethlink
  CRITICAL - check ethlink. check_ethlink - Mismatched interface/config mac addresses! |
  PCIE_5 (enp97s0f0np0) has bad cfg (expect: fa:ce:b0:0c:19:83, actual: 10:70:fd:bd:7d:5c)!
  PCIE_4 (enp225s0f0np0) has bad cfg (expect: fa:ce:b0:0c:19:83, actual: 10:70:fd:bd:51:8c)!

After the fix (installed a locally-built RPM containing this patch):

  $ sudo /bin/health_checks --config=... check-ethlink
  OK - check ethlink. check_ethlink

Also verified independently in shell that `802-3-ethernet.mac-address` from the NM connection profile matches the permanent MAC on both slaves:

  enp97s0f0np0: binding=10:70:FD:BD:7D:5C perm=10:70:fd:bd:7d:5c -> OK
  enp225s0f0np0: binding=10:70:FD:BD:51:8C perm=10:70:fd:bd:51:8c -> OK
