### PR TITLE
slurm: keep slurm_monitor alive on pre-release Slurm versions

### DIFF
--- a/gcm/monitoring/sink/utils.py
+++ b/gcm/monitoring/sink/utils.py
@@ -281,9 +281,9 @@ def print_tb(verbose: bool) -> None:
         return
 
     exc_info = sys.exc_info()
-    assert all(i is not None for i in exc_info), (
-        "Can only be called in an exception handler"
-    )
+    assert all(
+        i is not None for i in exc_info
+    ), "Can only be called in an exception handler"
     traceback.print_exception(*exc_info)
 
 

--- a/gcm/monitoring/sink/utils.py
+++ b/gcm/monitoring/sink/utils.py
@@ -36,7 +36,6 @@ import click
 from gcm.monitoring.decorators import exponential_backoff, OutOfRetries, retry
 from gcm.monitoring.itertools import chunk_by_json_size, json_dumps_dataclass
 from gcm.monitoring.sink.protocol import SinkAdditionalParams, SinkImpl, SinkWrite
-
 from gcm.schemas.log import Log
 
 if TYPE_CHECKING:
@@ -282,9 +281,9 @@ def print_tb(verbose: bool) -> None:
         return
 
     exc_info = sys.exc_info()
-    assert all(
-        i is not None for i in exc_info
-    ), "Can only be called in an exception handler"
+    assert all(i is not None for i in exc_info), (
+        "Can only be called in an exception handler"
+    )
     traceback.print_exception(*exc_info)
 
 
@@ -370,9 +369,6 @@ def write_to_sink_with_retries(
         raise click.ClickException(
             f"Failed even after retrying {retries} times. Please try again later."
         ) from e
-    except ValueError as e:
-        print_tb(verbose)
-        raise click.UsageError(str(e)) from e
     except Exception as e:
         print_tb(verbose)
         raise click.ClickException(

--- a/gcm/monitoring/slurm/sinfo.py
+++ b/gcm/monitoring/slurm/sinfo.py
@@ -2,7 +2,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 import logging
-import subprocess
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict
@@ -294,9 +293,6 @@ def compute_per_account_slurm_log(
 
 
 def get_slurm_version() -> tuple[int, ...]:
-    # Delegate to clusterscope's parser, which handles SchedMD pre-release and
-    # zero-padded versions (e.g. "26.05.2-0pre1"); avoids a second fragile
-    # int()-split of `sinfo -V` here.
     import clusterscope
 
     return clusterscope.slurm_version()

--- a/gcm/monitoring/slurm/sinfo.py
+++ b/gcm/monitoring/slurm/sinfo.py
@@ -11,7 +11,6 @@ from functools import reduce
 from typing import Any, DefaultDict, Dict, Generator, Optional
 
 from gcm.monitoring.clock import AwareDatetime, tz_aware_fromisoformat
-
 from gcm.monitoring.slurm.constants import (
     FAILED_JOB_STATES,
     NODE_DOWN_STATES,
@@ -295,10 +294,12 @@ def compute_per_account_slurm_log(
 
 
 def get_slurm_version() -> tuple[int, ...]:
-    cmd = ["sinfo", "-V"]
-    slurm_version = subprocess.check_output(cmd, text=True, timeout=10)
-    version = tuple(int(v) for v in slurm_version.strip().split(" ")[1].split("."))
-    return version
+    # Delegate to clusterscope's parser, which handles SchedMD pre-release and
+    # zero-padded versions (e.g. "26.05.2-0pre1"); avoids a second fragile
+    # int()-split of `sinfo -V` here.
+    import clusterscope
+
+    return clusterscope.slurm_version()
 
 
 @log_error


### PR DESCRIPTION
## Summary

`gcm slurm_monitor` crash-loops to a supervisord FATAL — taking down the Slurm controller's telemetry/accounting — on any cluster whose Slurm build reports a SchedMD pre-release version. `sinfo -V` returns e.g. `slurm 26.05.2-0pre1`; the version was parsed by `int()`-splitting each dotted component, so `int("2-0pre1")` raised `ValueError: invalid literal for int() with base 10: '2-0pre1'`, which was then re-raised as a `click.UsageError` (a misleading `Usage: ... Try --help` banner) and exited non-zero on every start.

Two changes:

- `monitoring/slurm/sinfo.py`: `get_slurm_version()` had its own fragile `int()`-split of `sinfo -V`. Delegate to `clusterscope.slurm_version()` (already a dependency), which parses SchedMD pre-release and zero-padded versions robustly (companion clusterscope change) — one parser instead of two.
- `monitoring/sink/utils.py`: drop the `except ValueError -> click.UsageError` branch in `write_to_sink_with_retries`, so a runtime `ValueError` (a data/parse error) falls through to the existing generic `except Exception -> click.ClickException` handler instead of being mislabeled a CLI usage error.

## Test Plan

`get_slurm_version()` is now `return clusterscope.slurm_version()`. That function parses every SchedMD form that previously crashed (with `sinfo -V` output mocked):

```
$ python -c "
from unittest.mock import patch
import clusterscope.lib as lib
for s in ['26.05.2-0pre1', '24.11.2-0pre1', '24.05.0']:
    with patch.object(lib, 'get_unified_info') as m:
        m.return_value.get_slurm_version.return_value = s
        print(f'{s:16} -> {lib.slurm_version()}')
"
26.05.2-0pre1    -> (26, 5, 2)
24.11.2-0pre1    -> (24, 11, 2)
24.05.0          -> (24, 5, 0)
```

`sink/utils.py` is an error-path change, verified by inspection of the `try/except`: the `OutOfRetries` and generic `Exception -> ClickException` branches are unchanged; only the intermediate `ValueError -> UsageError` reclassification is removed, so a data/parse error no longer surfaces as a bogus CLI usage error.