### PR TITLE
check_authentication: accept short-form passwd -S status on CentOS 10

### DIFF
--- a/gcm/health_checks/checks/check_authentication.py
+++ b/gcm/health_checks/checks/check_authentication.py
@@ -74,6 +74,19 @@ class AuthenticationCheckImpl:
         return shell_command(cmd, timeout_secs)
 
 
+# Shadow-utils changed the second field of `passwd -S` from the long form
+# (PS = "password set with hash-algo", LK = "locked") to a single letter
+# (P, L) in the CentOS 10 base image. Accept both forms so this check
+# works on both OSes without per-host --status overrides.
+_STATUS_ALIASES = {
+    "PS": {"PS", "P"},
+    "P": {"PS", "P"},
+    "LK": {"LK", "L"},
+    "L": {"LK", "L"},
+    "NP": {"NP"},
+}
+
+
 def process_pass_status(
     output: str, error_code: int, expected_state: str
 ) -> Tuple[ExitCode, str]:
@@ -83,12 +96,14 @@ def process_pass_status(
             f"passwd command FAILED to execute. error_code: {error_code} output: {output}\n",
         )
 
-    if output.strip() == expected_state:
+    observed = output.strip()
+    accepted = _STATUS_ALIASES.get(expected_state, {expected_state})
+    if observed in accepted:
         return ExitCode.OK, f"Password status as expected: {expected_state}"
     else:
         return (
             ExitCode.CRITICAL,
-            f"Password status {output.strip()} not as expected, {expected_state}",
+            f"Password status {observed!r} not in accepted forms {sorted(accepted)!r} for expected {expected_state!r}",
         )
 
 

--- a/gcm/tests/health_checks_tests/test_check_authentication.py
+++ b/gcm/tests/health_checks_tests/test_check_authentication.py
@@ -49,24 +49,47 @@ def auth_tester(
 
 
 @pytest.mark.parametrize(
-    "auth_tester, expected",
+    "auth_tester, expected_arg, expected",
     [
+        # CentOS 9 long-form output matches long-form expected
         (
             CompletedProcess(args=[], returncode=0, stdout="PS\n"),
-            (
-                ExitCode.OK,
-                "Password status as expected: PS",
-            ),
+            "PS",
+            (ExitCode.OK, "Password status as expected: PS"),
         ),
+        # CentOS 10 short-form output matches long-form expected (alias)
+        (
+            CompletedProcess(args=[], returncode=0, stdout="P\n"),
+            "PS",
+            (ExitCode.OK, "Password status as expected: PS"),
+        ),
+        # CentOS 10 short-form locked matches long-form locked expected (alias)
         (
             CompletedProcess(args=[], returncode=0, stdout="L\n"),
-            (
-                ExitCode.CRITICAL,
-                "Password status L not as expected, PS",
-            ),
+            "LK",
+            (ExitCode.OK, "Password status as expected: LK"),
+        ),
+        # CentOS 9 long-form locked still works
+        (
+            CompletedProcess(args=[], returncode=0, stdout="LK\n"),
+            "LK",
+            (ExitCode.OK, "Password status as expected: LK"),
+        ),
+        # Genuine mismatch: no-password when password expected → CRITICAL
+        (
+            CompletedProcess(args=[], returncode=0, stdout="NP\n"),
+            "PS",
+            (ExitCode.CRITICAL, "'NP'"),
+        ),
+        # Locked when password expected → CRITICAL (both forms)
+        (
+            CompletedProcess(args=[], returncode=0, stdout="L\n"),
+            "PS",
+            (ExitCode.CRITICAL, "'L'"),
         ),
         (
             CompletedProcess(args=[], returncode=2, stdout="Error"),
+            "PS",
             (
                 ExitCode.WARN,
                 "passwd command FAILED to execute. error_code: 2 output: Error",
@@ -79,6 +102,7 @@ def test_pass_status(
     caplog: pytest.LogCaptureFixture,
     tmp_path: Path,
     auth_tester: FakeAuthenticationCheckImpl,
+    expected_arg: str,
     expected: Tuple[ExitCode, str],
 ) -> None:
     runner = CliRunner(mix_stderr=False)
@@ -86,7 +110,7 @@ def test_pass_status(
 
     result = runner.invoke(
         password_status,
-        f"fair_cluster prolog --log-folder={tmp_path} --sink=do_nothing -u userA -s PS",
+        f"fair_cluster prolog --log-folder={tmp_path} --sink=do_nothing -u userA -s {expected_arg}",
         obj=auth_tester,
     )
 

--- a/website/docs/GCM_Health_Checks/health_checks/check-authentication/password-status.md
+++ b/website/docs/GCM_Health_Checks/health_checks/check-authentication/password-status.md
@@ -23,10 +23,19 @@ Checks if a user's password status matches expected configuration using `passwd 
 | `--heterogeneous-cluster-v1` | Flag | False | Enable heterogeneous cluster support |
 
 ## Password Status Codes
-- **PS**: Password set
-- **LK**: Password locked
-- **NP**: No password
-- **L**: Password locked (alternative format)
+
+`passwd -S` prints the second field as a short status token. The set of tokens
+changed between shadow-utils versions: CentOS Stream 9 and earlier print the
+long form (`PS`, `LK`), while CentOS Stream 10 (newer shadow-utils) print the
+single-letter form (`P`, `L`). The check accepts both forms for each state, so
+passing `--status PS` matches a `P` output and vice versa. This avoids per-host
+`--status` overrides during the CentOS 10 rollout.
+
+| Expected (`--status`) | Meaning | Accepted `passwd -S` outputs |
+|--|--|--|
+| `PS` (or `P`) | Password set | `PS`, `P` |
+| `LK` (or `L`) | Password locked | `LK`, `L` |
+| `NP` | No password | `NP` |
 
 ## Exit Conditions
 


### PR DESCRIPTION
## Summary

CentOS 10 shadow-utils dropped the hash-algorithm suffix from `passwd -S`'s second field: PS→P and LK→L. Production callers use the default expected value (PS), so check-authentication password-status returned CRITICAL on every CentOS 10 host (T279791158 repro on sbxlearn1983).

Add an alias set per state so both long-form and short-form outputs match the same expected value. Preserves CLI back-compat for any caller passing `-s PS` or `-s LK` explicitly.

## Test Plan

Unit tests (in ~/rsc/gcm):
  $ pytest gcm/tests/health_checks_tests/test_check_authentication.py -v
  9 passed — covers all 7 parametrized test_pass_status cases
  (PS→PS OK, P→PS OK, LK→LK OK, L→LK OK, NP→PS CRITICAL, L→PS CRITICAL, WARN)
  plus the two test_check_path_access_by_user cases.

On-host verification (RPM built with this fix, installed via localinstall):

CentOS 10 — sbxlearn1983:
  $ sudo /bin/health_checks --config=/etc/gcm_health_checks/config.toml \
      --features-config=/etc/gcm_health_checks/killswitches.toml \
      check-authentication password-status
  OK - check password status. Password status as expected: PS
   -- (previously: CRITICAL - Password status P not as expected, PS)

CentOS 9 regression — sbxcpu1068:
  $ sudo /bin/health_checks --config=/etc/gcm_health_checks/config.toml \
      --features-config=/etc/gcm_health_checks/killswitches.toml \
      check-authentication password-status
  OK - check password status. Password status as expected: PS
  -- confirms no regression: c9 long-form (PS) still matches default expected (PS)
