### PR TITLE
Fix Slurm GPU GRES and OTel boolean metrics

### DIFF
--- a/gcm/exporters/otel.py
+++ b/gcm/exporters/otel.py
@@ -173,12 +173,15 @@ class Otel:
                 metric_name = field.name
                 metric_value = getattr(message, metric_name)
 
+                if isinstance(metric_value, bool):
+                    metric_value = int(metric_value)
+                if not isinstance(metric_value, int | float):
+                    logger.warning(
+                        f"Unsupported data type for OTel logging: {type(metric_value)}, ignoring metric {metric_name}"
+                    )
+                    continue
+
                 if metric_name not in self.metrics_instruments:
-                    if not isinstance(metric_value, int | float):
-                        logger.warning(
-                            f"Unsupported data type for OTel logging: {type(metric_value)}, ignoring metric {metric_name}"
-                        )
-                        continue
                     self.metrics_instruments[metric_name] = self.meter.create_gauge(
                         metric_name, description=metric_name
                     )

--- a/gcm/monitoring/slurm/parsing.py
+++ b/gcm/monitoring/slurm/parsing.py
@@ -152,7 +152,7 @@ def convert_memory_to_mb(value: str) -> int:
 
 
 def parse_gres(v: str) -> int:
-    """Parse a GRES string of the form: gpu:{pascal|volta}:<number>[(<stuff>)]
+    """Parse a GRES string of the form: gpu:<type>:<number>[(<stuff>)]
 
     Examples:
 
@@ -177,14 +177,15 @@ def parse_gres(v: str) -> int:
                         at_least_zero(
                             chain(
                                 [
-                                    # GPU type, e.g. 'pascal', 'volta', or 'H100'.  Match
-                                    # anything beginning with an ascii letter.
+                                    # GPU type, e.g. 'volta', 'H100', or
+                                    # 'nvidia_gb300'.
                                     at_least_one(
                                         first_of(
                                             [
                                                 begins_with(c)
                                                 for c in string.ascii_letters
                                                 + string.digits
+                                                + "_"
                                             ]
                                         )
                                     ),

--- a/gcm/tests/test_otel.py
+++ b/gcm/tests/test_otel.py
@@ -3,6 +3,7 @@
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 from gcm.monitoring.sink.protocol import DataType, SinkAdditionalParams
 from gcm.schemas.log import Log
@@ -14,6 +15,16 @@ if TYPE_CHECKING:
 @dataclass
 class _OtelDummyMsg:
     field_a: int = 7
+
+
+@dataclass
+class _OtelBooleanMetricMsg:
+    healthy: bool = True
+
+
+@dataclass
+class _OtelOptionalMetricMsg:
+    value: int | None
 
 
 class _CaptureHandler(logging.Handler):
@@ -73,6 +84,40 @@ class TestOtelLoggerBehavior:
             assert extra.get("time") == 42
         finally:
             otel.otel_logger.removeHandler(capture)
+            otel.shutdown()
+
+    def test_boolean_metric_is_exported_as_integer(self) -> None:
+        otel = self._make_otel()
+        gauge = MagicMock()
+        otel.meter = MagicMock()
+        otel.meter.create_gauge.return_value = gauge
+        try:
+            otel.write(
+                Log(ts=42, message=[_OtelBooleanMetricMsg(healthy=True)]),
+                SinkAdditionalParams(data_type=DataType.METRIC),
+            )
+            gauge.set.assert_called_once_with(amount=1)
+        finally:
+            otel.shutdown()
+
+    def test_invalid_metric_value_is_skipped_after_instrument_creation(self) -> None:
+        otel = self._make_otel()
+        gauge = MagicMock()
+        otel.meter = MagicMock()
+        otel.meter.create_gauge.return_value = gauge
+        try:
+            otel.write(
+                Log(
+                    ts=42,
+                    message=[
+                        _OtelOptionalMetricMsg(value=7),
+                        _OtelOptionalMetricMsg(value=None),
+                    ],
+                ),
+                SinkAdditionalParams(data_type=DataType.METRIC),
+            )
+            gauge.set.assert_called_once_with(amount=7)
+        finally:
             otel.shutdown()
 
 

--- a/gcm/tests/test_parsers.py
+++ b/gcm/tests/test_parsers.py
@@ -490,6 +490,8 @@ class TestSLURMParsing:
         [
             ("gpu:volta:8(S:0-1)", 8),
             ("gpu:pascal:2", 2),
+            ("gpu:nvidia_gb200:2(S:0-1)", 2),
+            ("gpu:nvidia_gb300:4(S:0-1)", 4),
             ("N/A", 0),
             ("gpu:8", 8),
             ("(null)", 0),


### PR DESCRIPTION
## Summary

Slurm reports GB200 and GB300 resources as `gpu:nvidia_gb200:2(S:0-1)` and `gpu:nvidia_gb300:4(S:0-1)`. The GRES parser accepted only alphanumeric type names, so these valid underscore-bearing values terminated cluster monitoring.

Accept underscores in GPU type names. Normalize boolean gauges to integers before export because Python treats `bool` as an `int`, while OpenTelemetry rejects boolean `NumberDataPoint` values. Validate every sample so a later optional or otherwise nonnumeric value cannot bypass the check after its gauge has been created.

## Test Plan

```text
$ uv run --python /usr/local/bin/python3.12 --extra dev pytest gcm/tests/test_parsers.py gcm/tests/test_otel.py
118 passed, 5 warnings in 1.68s
```

Live sanity checks confirmed both underscore-bearing GRES formats.