### PR TITLE
shelper: enumerate node jobs via squeue in slurmctld mode

### DIFF
--- a/shelper/entrypoint.go
+++ b/shelper/entrypoint.go
@@ -33,7 +33,12 @@ func GetGPU2Slurm(cfg *Config) (map[string]SlurmMetadata, []string, error) {
 		if slurmNodeName := os.Getenv("SLURMD_NODENAME"); slurmNodeName != "" {
 			hostname = slurmNodeName
 		}
-		_, jobIDs, err = GetJob2Pid()
+		// Enumerate this node's jobs through slurmctld rather than
+		// `scontrol listpids`: listpids needs a node-local slurmd (its spool
+		// socket), which does not exist when the collector runs in a
+		// separate container or Pod. squeue -w also reports allocated jobs
+		// that have not started a step yet, which still hold GPUs.
+		jobIDs, err = GetSlurmJobIDsSqueueForHost(hostname)
 		if err != nil {
 			return GPU2Slurm, jobIDs, err
 		}

--- a/shelper/entrypoint.go
+++ b/shelper/entrypoint.go
@@ -33,11 +33,6 @@ func GetGPU2Slurm(cfg *Config) (map[string]SlurmMetadata, []string, error) {
 		if slurmNodeName := os.Getenv("SLURMD_NODENAME"); slurmNodeName != "" {
 			hostname = slurmNodeName
 		}
-		// Enumerate this node's jobs through slurmctld rather than
-		// `scontrol listpids`: listpids needs a node-local slurmd (its spool
-		// socket), which does not exist when the collector runs in a
-		// separate container or Pod. squeue -w also reports allocated jobs
-		// that have not started a step yet, which still hold GPUs.
 		jobIDs, err = GetSlurmJobIDsSqueueForHost(hostname)
 		if err != nil {
 			return GPU2Slurm, jobIDs, err

--- a/shelper/squeue.go
+++ b/shelper/squeue.go
@@ -11,11 +11,20 @@ import (
 // GetSlurmJobIDsSqueue queries slurmctld for the job ids of all jobs running on this host, it returns a comma separated string of job ids.
 func GetSlurmJobIDsSqueue() ([]string, error) {
 	hostname, err := GetHostname()
+	if err != nil {
+		return []string{}, err
+	}
+	return GetSlurmJobIDsSqueueForHost(hostname)
+}
+
+// GetSlurmJobIDsSqueueForHost queries slurmctld for the job ids of all jobs
+// running on the given host. Unlike `scontrol listpids`, this does not need a
+// node-local slurmd, so callers that already know the Slurm node name (for
+// example from SLURMD_NODENAME on Kubernetes, where the OS hostname differs
+// from Slurm's NodeList) can run in a separate container or Pod.
+func GetSlurmJobIDsSqueueForHost(hostname string) ([]string, error) {
 	jobIDs := []string{}
 
-	if err != nil {
-		return jobIDs, err
-	}
 	// -h: remove slurm headers from output
 	// -w <hostname>: only get jobs running on the given host
 	// -o <field>: output only the given field
@@ -30,8 +39,7 @@ func GetSlurmJobIDsSqueue() ([]string, error) {
 
 	cmdErr := cmd.Run()
 	if cmdErr != nil {
-		err = fmt.Errorf("%w: %v", cmdErr, stderr.String())
-		return jobIDs, err
+		return jobIDs, fmt.Errorf("%w: %v", cmdErr, stderr.String())
 	}
 
 	jobIDs = parseNewLineToList(out.String())

--- a/shelper/squeue.go
+++ b/shelper/squeue.go
@@ -17,11 +17,6 @@ func GetSlurmJobIDsSqueue() ([]string, error) {
 	return GetSlurmJobIDsSqueueForHost(hostname)
 }
 
-// GetSlurmJobIDsSqueueForHost queries slurmctld for the job ids of all jobs
-// running on the given host. Unlike `scontrol listpids`, this does not need a
-// node-local slurmd, so callers that already know the Slurm node name (for
-// example from SLURMD_NODENAME on Kubernetes, where the OS hostname differs
-// from Slurm's NodeList) can run in a separate container or Pod.
 func GetSlurmJobIDsSqueueForHost(hostname string) ([]string, error) {
 	jobIDs := []string{}
 


### PR DESCRIPTION
## Motivation

In `slurmctld` metadata mode, `GetGPU2Slurm` only uses `scontrol listpids` to learn **which jobs are on the node** — the returned PID map is discarded. `listpids` requires a node-local slurmd, which doesn't exist when the collector runs in a separate container/Pod: e.g. a telemetry DaemonSet on a Kubernetes-based Slurm cluster, where the slurmd Pod does not expose its spool directory outside itself. That currently forces the slurmprocessor collector to be a slurmd sidecar even though everything else it needs (Munge + network to slurmctld) is available to a standalone Pod.

## Change

- `slurmctld` mode now enumerates the node's jobs with `squeue -h -w <node> -o %i`, asking slurmctld instead of the local slurmd. The existing `SLURMD_NODENAME` override flows through, so Kubernetes deployments where the OS hostname differs from Slurm's NodeList keep correct attribution.
- `GetSlurmJobIDsSqueue` keeps its exact behavior and delegates to a new host-parameterized `GetSlurmJobIDsSqueueForHost`.
- `slurmd` mode is untouched — it genuinely needs the `listpids` PID map.

## Semantics

`listpids` reports jobs with running processes; `squeue -w` reports jobs allocated on the node, including allocations that haven't started a step yet — which still hold GPUs, so attribution coverage is equal or better. Pending jobs don't match `-w` (empty NodeList).

## Testing

```
$ cd shelper && go build ./... && go vet ./... && go test ./...
ok  github.com/facebookresearch/gcm/shelper
$ cd ../slurmprocessor && go mod edit -replace github.com/facebookresearch/gcm/shelper=../shelper && go build ./...
# builds clean (the local replace mirrors the OCB collector build; slurmprocessor@main
# doesn't build against the proxy-released shelper regardless of this change)
```

Planned live validation: an OpenTelemetry collector built at this ref, running as a standalone DaemonSet on a Kubernetes-based Slurm cluster, joining the cluster's existing DCGM exporter series with a known Slurm allocation.