### PR TITLE
Doc: graph_api warns+skips (names DataIdentifier) on missing scribe_category

### DIFF
--- a/website/docs/GCM_Monitoring/exporters/graph_api.md
+++ b/website/docs/GCM_Monitoring/exporters/graph_api.md
@@ -19,7 +19,7 @@ The Graph API exporter is a Meta-specific sink that writes monitoring data and h
 | `pure_scribe_category` | `PURE` | `sacct_publish` |
 | `sdiag_scribe_category` | `SDIAG` | `slurm_monitor` (sdiag dual-publish) |
 
-`sdiag_scribe_category` is the LOG-path target for the `slurm_monitor` collector's dual-publish; the METRIC-path ODS write is unaffected. If a collector emits `DataIdentifier.SDIAG` and `sdiag_scribe_category` is unset, `graph_api._write_log` raises `AssertionError("scribe_category argument is missing")` rather than silently dropping the row.
+`sdiag_scribe_category` is the LOG-path target for the `slurm_monitor` collector's dual-publish; the METRIC-path ODS write is unaffected. If a collector emits `DataIdentifier.SDIAG` and `sdiag_scribe_category` is unset, `graph_api._write_log` logs a warning naming the missing LOG stream (e.g. `SDIAG`) and skips its writes, warning once per stream rather than silently dropping the row.
 
 ## Adding a new scribe category (Meta-internal)
 


### PR DESCRIPTION
Summary:
The SEV-followup asked that a missing `scribe_category` failure identify **which** `DataIdentifier`/LOG stream is unconfigured.

The code fix already landed in `D111076896` (PR #169, `5d5e867a8529`): `graph_api._write_log` no longer raises the generic `AssertionError("scribe_category argument is missing")`. It now logs a warning naming the missing stream (`stream.name`, e.g. `SDIAG`) and skips its writes, warning once per stream. Regression tests in `TestGraphAPISdiagRouting` assert `"SDIAG"` appears in the message.

The only remaining gap was the exporter doc, which still described the old `AssertionError` behavior. This diff updates `website/docs/GCM_Monitoring/exporters/graph_api.md` to match the shipped warn-and-skip behavior. Doc-only change; no code behavior change.

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=943b3044-b7f4-45de-8f2d-629e13a9aac7)

Differential Revision: D117419636


